### PR TITLE
Migrate visualiser UI to shadcn

### DIFF
--- a/apps/visualiser/components.json
+++ b/apps/visualiser/components.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": false,
+  "tsx": false,
+  "tailwind": {
+    "config": "",
+    "css": "src/index.css",
+    "baseColor": "neutral",
+    "cssVariables": true
+  },
+  "iconLibrary": "lucide",
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  }
+}

--- a/apps/visualiser/jsconfig.json
+++ b/apps/visualiser/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/apps/visualiser/package-lock.json
+++ b/apps/visualiser/package-lock.json
@@ -8,21 +8,121 @@
       "name": "visualiser",
       "version": "0.0.0",
       "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.23",
+        "@radix-ui/react-dropdown-menu": "^2.1.24",
+        "@radix-ui/react-slot": "^1.3.3",
+        "@radix-ui/react-tooltip": "^1.2.16",
         "@techstark/opencv-js": "^5.0.0-release.1",
         "@xyflow/react": "^12.11.2",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
         "elkjs": "^0.12.0",
         "fflate": "^0.8.3",
+        "lucide-react": "^1.31.0",
         "pixelmatch": "^7.2.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
+        "sonner": "^2.0.8",
+        "tailwind-merge": "^3.6.0",
         "yaml": "^2.9.0"
       },
       "devDependencies": {
+        "@tailwindcss/vite": "^4.3.3",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.4",
         "oxlint": "^1.75.0",
+        "tailwindcss": "^4.3.3",
+        "tw-animate-css": "^1.4.0",
         "vite": "^8.2.0"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -382,6 +482,633 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+      "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+      "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.23.tgz",
+      "integrity": "sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+      "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-effect-event": "0.0.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.24.tgz",
+      "integrity": "sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-menu": "2.1.24",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.24.tgz",
+      "integrity": "sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+      "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-rect": "1.1.4",
+        "@radix-ui/react-use-size": "1.1.4",
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+      "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.16.tgz",
+      "integrity": "sha512-6EamKFRRnlpdadndbZ6LMwycfwkwPte1B42hs6QA0gYhjaOKqW4PZ4pjaW9UrlDX5eVt/OjncE7BFTPL5nmZhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-visually-hidden": "1.2.11"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+      "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+      "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+      "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.11.tgz",
+      "integrity": "sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+      "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
@@ -645,6 +1372,563 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.24.1",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+      "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "tailwindcss": "4.3.3"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
     "node_modules/@techstark/opencv-js": {
       "version": "5.0.0-release.1",
       "resolved": "https://registry.npmjs.org/@techstark/opencv-js/-/opencv-js-5.0.0-release.1.tgz",
@@ -788,11 +2072,44 @@
         "d3-zoom": "^3.0.0"
       }
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/classcat": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
       "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -916,11 +2233,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
     "node_modules/elkjs": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.12.0.tgz",
       "integrity": "sha512-YZcKynxVxYoKIOEpywEPwCFdg+BTbxQRNf3pbwdDCvc8O3kQD8bmIwSxKU1eOTVc4Xo+VG9Te+575mlfvOrhEQ==",
       "license": "EPL-2.0 OR GPL-3.0-or-later"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -959,6 +2296,32 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/lightningcss": {
@@ -1234,6 +2597,25 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.31.0.tgz",
+      "integrity": "sha512-G8u2eEtoHUnUa9f8lbvqDhCiORMnYLdUEo06EEG9MQvHQrInKcX3Pa2TH39MM5qyzRcWETxB0+aOwAPI1g1kEg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.18",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
@@ -1393,6 +2775,75 @@
         "react": "^19.2.8"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
@@ -1432,6 +2883,22 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/sonner": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.8.tgz",
+      "integrity": "sha512-UM/ByIoFra8yzV75n1o0Puu0bw5U/9UNnDacrJNspekBewIfsQ3D6ez1nvlWpt7aTsO6rujQtifBpycwIivqlg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1440,6 +2907,37 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tinyglobby": {
@@ -1457,6 +2955,65 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tw-animate-css": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
+      "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Wombosvideo"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {

--- a/apps/visualiser/package.json
+++ b/apps/visualiser/package.json
@@ -10,20 +10,32 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.23",
+    "@radix-ui/react-dropdown-menu": "^2.1.24",
+    "@radix-ui/react-slot": "^1.3.3",
+    "@radix-ui/react-tooltip": "^1.2.16",
     "@techstark/opencv-js": "^5.0.0-release.1",
     "@xyflow/react": "^12.11.2",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "elkjs": "^0.12.0",
     "fflate": "^0.8.3",
+    "lucide-react": "^1.31.0",
     "pixelmatch": "^7.2.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
+    "sonner": "^2.0.8",
+    "tailwind-merge": "^3.6.0",
     "yaml": "^2.9.0"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.3.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.4",
     "oxlint": "^1.75.0",
+    "tailwindcss": "^4.3.3",
+    "tw-animate-css": "^1.4.0",
     "vite": "^8.2.0"
   }
 }

--- a/apps/visualiser/src/App.jsx
+++ b/apps/visualiser/src/App.jsx
@@ -1,7 +1,14 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Background, Controls, MarkerType, MiniMap, ReactFlow, useReactFlow, ReactFlowProvider } from '@xyflow/react'
+import { ChevronLeft, ChevronRight, Copy, Map as MapIcon, PanelLeftClose, PanelLeftOpen, RotateCcw, Sparkles, Upload, X } from 'lucide-react'
+import { toast as notify, Toaster } from 'sonner'
 import '@xyflow/react/dist/style.css'
 import ScreenNode from './components/ScreenNode'
+import { Badge } from './components/ui/badge'
+import { Button } from './components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './components/ui/card'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from './components/ui/dialog'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './components/ui/tooltip'
 import { flowResolution, isInteractive, loadBundle, mergeBundles } from './lib/loadBundle'
 import { layoutGraph, NODE_H, NODE_W } from './lib/layout'
 import { flowForNode, replayCommand } from './lib/replay'
@@ -46,9 +53,7 @@ function Graph({ bundle, onOpenBuffer, onCloseDiff }) {
     return init
   })
   const [neighboursMode, setNeighboursMode] = useState(false)
-  const [toast, setToast] = useState(null)
   const [flowsOpen, setFlowsOpen] = useState(() => window.innerWidth > 900)
-  const toastTimer = useRef(null)
   const { fitView, setCenter, getZoom } = useReactFlow()
 
   // shared clock for the in-place base/head comparator on changed screens —
@@ -62,8 +67,8 @@ function Graph({ bundle, onOpenBuffer, onCloseDiff }) {
 
   const { paths, nodeAtStep } = useMemo(() => flowResolution(map), [map])
   const routeById = useMemo(() => Object.fromEntries(map.nodes.map((n) => [n.id, n])), [map])
-  const flow = selectedFlow ? map.flows.find((f) => f.name === selectedFlow) : null
-  const path = flow ? paths[flow.name] ?? [] : []
+  const flow = useMemo(() => selectedFlow ? map.flows.find((f) => f.name === selectedFlow) : null, [selectedFlow, map])
+  const path = useMemo(() => flow ? paths[flow.name] ?? [] : [], [flow, paths])
 
   // transitions observed in flow recordings but absent from static analysis
   // (e.g. drawer links living in shared components) — permanent dashed edges
@@ -202,9 +207,7 @@ function Graph({ bundle, onOpenBuffer, onCloseDiff }) {
   )
 
   const showToast = useCallback((msg) => {
-    clearTimeout(toastTimer.current)
-    setToast(msg)
-    toastTimer.current = setTimeout(() => setToast(null), 2600)
+    notify(msg)
   }, [])
 
   const [commandSheet, setCommandSheet] = useState(null)
@@ -301,7 +304,7 @@ function Graph({ bundle, onOpenBuffer, onCloseDiff }) {
         },
       }
     })
-  }, [positions, map, images, flow, path, currentNodeId, stateOverrides, selectedNode, chosenStates, selectedEdge, edgeGesture, neighbourhood, subjectId, diffMode, flip])
+  }, [positions, map, images, flow, path, currentNodeId, stateOverrides, selectedNode, chosenStates, selectedEdge, edgeGesture, gesture, neighbourhood, subjectId, diffMode, flip])
 
   const rfEdges = useMemo(() => {
     const infos = new Map()
@@ -368,7 +371,7 @@ function Graph({ bundle, onOpenBuffer, onCloseDiff }) {
   )
 
   useEffect(() => {
-    document.querySelector('.flow-item.active')?.scrollIntoView({ block: 'nearest' })
+    document.querySelector('[data-flow-item].active')?.scrollIntoView({ block: 'nearest' })
   }, [selectedFlow])
 
   // camera follows the playhead: every step focuses the screen it acts on
@@ -414,6 +417,7 @@ function Graph({ bundle, onOpenBuffer, onCloseDiff }) {
   if (!positions) return <div className="loading">laying out {map.nodes.length} screens…</div>
 
   return (
+    <TooltipProvider delayDuration={250}>
     <div className="graph-root">
       <ReactFlow
         nodes={rfNodes}
@@ -484,19 +488,21 @@ function Graph({ bundle, onOpenBuffer, onCloseDiff }) {
         />
       </ReactFlow>
 
-      <header className="hud hud-top">
-        <div className="brand">
-          <span className="mark" />
-          <div>
-            <h1>
+      <Card className="absolute left-4 top-4 z-10 flex-row items-center gap-5 rounded-xl bg-card/90 px-4 py-3 shadow-xl backdrop-blur-xl">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
+            <MapIcon className="size-4" />
+          </div>
+          <div className="min-w-0">
+            <h1 className="flex items-center text-sm font-semibold tracking-tight">
               {manifest.app.name}
               {diffMode && (
-                <span className="diff-mode-tag">
+                <Badge variant="secondary" className="ml-2 border border-primary/20 bg-primary/10 text-[10px] text-primary">
                   {manifest.pr ? `PR #${manifest.pr.number}` : 'diff'}
-                </span>
+                </Badge>
               )}
             </h1>
-            <p className="sub">
+            <p className="max-w-72 truncate text-[11px] text-muted-foreground">
               {diffMode
                 ? `${manifest.pr?.title ??
                     `${(manifest.base?.commit ?? 'base').slice(0, 7)} → ${(manifest.head?.commit ?? 'head').slice(0, 7)}`}${bundle.backdrop ? ' · over full map' : ''}`
@@ -505,49 +511,58 @@ function Graph({ bundle, onOpenBuffer, onCloseDiff }) {
           </div>
         </div>
         {diffMode ? (
-          <div className="stats">
-            <span className="diff-a"><b>+{diffStats.A}</b> added</span>
-            <span className="diff-m"><b>±{diffStats.M}</b> changed</span>
-            <span className="diff-d"><b>−{diffStats.D}</b> removed</span>
-            <span><b>{diffStats.edges}</b> edge{diffStats.edges === 1 ? '' : 's'}</span>
+          <div className="hidden items-center gap-3 text-xs text-muted-foreground lg:flex">
+            <span><b className="text-emerald-400">+{diffStats.A}</b> added</span>
+            <span><b className="text-amber-400">±{diffStats.M}</b> changed</span>
+            <span><b className="text-red-400">−{diffStats.D}</b> removed</span>
+            <span><b className="text-foreground">{diffStats.edges}</b> edge{diffStats.edges === 1 ? '' : 's'}</span>
           </div>
         ) : (
-          <div className="stats">
-            <span><b>{stats.screens}</b> screens</span>
-            <span><b>{stats.captured}</b> captured</span>
-            <span><b>{stats.flows}</b> flows</span>
+          <div className="hidden items-center gap-3 text-xs text-muted-foreground lg:flex">
+            <span><b className="text-foreground">{stats.screens}</b> screens</span>
+            <span><b className="text-foreground">{stats.captured}</b> captured</span>
+            <span><b className="text-foreground">{stats.flows}</b> flows</span>
           </div>
         )}
-        <label className="open-chip" title="open a different .appmap or .appmapdiff bundle">
-          <input
-            type="file"
-            accept=".appmap,.appmapdiff,.zip"
-            onChange={async (e) => {
-              const f = e.target.files?.[0]
-              if (f) onOpenBuffer(await f.arrayBuffer())
-              e.target.value = ''
-            }}
-          />
-          ⇆ open bundle
-        </label>
+        <Button variant="outline" size="sm" asChild>
+          <label className="cursor-pointer" title="open a different .appmap or .appmapdiff bundle">
+            <Upload />
+            Open bundle
+            <input
+              className="hidden"
+              type="file"
+              accept=".appmap,.appmapdiff,.zip"
+              onChange={async (e) => {
+                const f = e.target.files?.[0]
+                if (f) onOpenBuffer(await f.arrayBuffer())
+                e.target.value = ''
+              }}
+            />
+          </label>
+        </Button>
         {diffMode && (
-          <button className="open-chip" title="close the diff overlay" onClick={onCloseDiff}>
-            ✕ close diff
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button variant="ghost" size="icon-sm" onClick={onCloseDiff}><X /></Button>
+            </TooltipTrigger>
+            <TooltipContent>Close diff</TooltipContent>
+          </Tooltip>
         )}
-      </header>
+      </Card>
 
-      <aside className={`hud flows-panel ${flowsOpen ? '' : 'collapsed'}`}>
-        <button className="panel-head" onClick={() => setFlowsOpen((o) => !o)}>
-          <h2>{diffMode ? 'Changes' : 'Agent flows'}</h2>
-          <span className="chev">{flowsOpen ? '−' : '+'}</span>
-        </button>
+      <Card className="absolute left-4 top-[84px] z-10 max-h-[calc(100%-112px)] w-64 gap-0 overflow-hidden rounded-xl bg-card/90 py-0 shadow-xl backdrop-blur-xl">
+        <Button variant="ghost" className="h-11 w-full justify-between rounded-none px-4" onClick={() => setFlowsOpen((o) => !o)}>
+          <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{diffMode ? 'Changes' : 'Agent flows'}</span>
+          {flowsOpen ? <PanelLeftClose /> : <PanelLeftOpen />}
+        </Button>
         {flowsOpen && diffMode && (
-          <div className="flow-list">
+          <div className="overflow-y-auto px-2 pb-2">
             {diff.nodes.map((d) => (
-              <button
+              <Button
                 key={d.id}
-                className={`flow-item ${selectedNode === d.id ? 'active' : ''}`}
+                data-flow-item
+                variant="ghost"
+                className={`h-9 w-full justify-start px-2 text-xs ${selectedNode === d.id ? 'active bg-accent text-accent-foreground' : ''}`}
                 onClick={(e) => {
                   e.currentTarget.blur()
                   setSelectedEdge(null)
@@ -556,14 +571,14 @@ function Graph({ bundle, onOpenBuffer, onCloseDiff }) {
                 }}
                 title={d.reason}
               >
-                <span className={`chg-badge chg-${d.status.toLowerCase()}`}>
+                <Badge variant="outline" className={`size-5 px-0 chg-${d.status.toLowerCase()}`}>
                   {d.status === 'A' ? '+' : d.status === 'D' ? '−' : '±'}
-                </span>
-                <span className="flow-name">{routeById[d.id]?.urlPath ?? d.id}</span>
-              </button>
+                </Badge>
+                <span className="truncate">{routeById[d.id]?.urlPath ?? d.id}</span>
+              </Button>
             ))}
             {diff.broadFiles?.length > 0 && (
-              <p className="broad-note" title={diff.broadFiles.map((b) => b.file).join('\n')}>
+              <p className="m-2 rounded-md border border-amber-400/20 bg-amber-400/10 p-2 text-[10px] leading-relaxed text-amber-300" title={diff.broadFiles.map((b) => b.file).join('\n')}>
                 {diff.broadFiles.length} broadly-imported changed file
                 {diff.broadFiles.length === 1 ? '' : 's'} excluded from suspect marking
               </p>
@@ -571,26 +586,28 @@ function Graph({ bundle, onOpenBuffer, onCloseDiff }) {
           </div>
         )}
         {flowsOpen && !diffMode && (
-          <div className="flow-list">
+          <div className="overflow-y-auto px-2 pb-2">
             {interactiveFlows.map((f) => (
-              <button
+              <Button
                 key={f.name}
-                className={`flow-item ${selectedFlow === f.name ? 'active' : ''}`}
+                data-flow-item
+                variant="ghost"
+                className={`h-9 w-full justify-start px-2 text-xs ${selectedFlow === f.name ? 'active bg-accent text-accent-foreground' : ''}`}
                 onClick={(e) => { e.currentTarget.blur(); selectFlow(f.name) }}
                 title={f.title}
               >
-                <span className="flow-kind interactive">✦</span>
-                <span className="flow-name">{f.title ?? f.name}</span>
-              </button>
+                <Sparkles className="text-cyan-400" />
+                <span className="truncate">{f.title ?? f.name}</span>
+              </Button>
             ))}
           </div>
         )}
-      </aside>
+      </Card>
 
       {flow && (
-        <footer className="hud playhead">
-          <div className="ph-title">
-            <b>
+        <Card className="absolute bottom-4 left-1/2 z-10 w-[min(600px,calc(100vw-320px))] -translate-x-1/2 gap-3 rounded-xl bg-card/95 px-4 py-4 shadow-2xl backdrop-blur-xl max-[900px]:left-4 max-[900px]:w-[calc(100vw-32px)] max-[900px]:translate-x-0">
+          <div className="flex items-center justify-between gap-3 text-sm">
+            <b className="min-w-0 flex-1 truncate">
               {neighboursMode
                 ? `Neighbours of ${routeById[subjectId]?.urlPath ?? subjectId}`
                 : flow.title ?? flow.name}
@@ -607,49 +624,53 @@ function Graph({ bundle, onOpenBuffer, onCloseDiff }) {
               // interaction) is "navigate" mode; visit-* is "deep link"
               const isVisit = flow.name.startsWith('visit-')
               return (
-                <div className="ph-toggle">
+                <div className="flex shrink-0 rounded-lg bg-muted p-1">
                   {(nav || !isVisit) && (
-                    <button
-                      className={!neighboursMode && !isVisit ? 'on' : ''}
+                    <Button
+                      variant={!neighboursMode && !isVisit ? 'secondary' : 'ghost'}
+                      size="sm"
+                      className="h-6 rounded-md px-2 text-[10px]"
                       onClick={() => nav && pick(nav)}
-                    >navigate</button>
+                    >Navigate</Button>
                   )}
                   {visit && (
-                    <button className={!neighboursMode && isVisit ? 'on' : ''} onClick={() => pick(visit)}>deep link</button>
+                    <Button variant={!neighboursMode && isVisit ? 'secondary' : 'ghost'} size="sm" className="h-6 rounded-md px-2 text-[10px]" onClick={() => pick(visit)}>Deep link</Button>
                   )}
-                  <button className={neighboursMode ? 'on' : ''} onClick={() => setNeighboursMode(true)}>neighbours</button>
+                  <Button variant={neighboursMode ? 'secondary' : 'ghost'} size="sm" className="h-6 rounded-md px-2 text-[10px]" onClick={() => setNeighboursMode(true)}>Neighbours</Button>
                 </div>
               )
             })()}
-            {!neighboursMode && <span className="ph-count">{stepView.pos + 1} / {stepView.visibleIdx.length}</span>}
+            {!neighboursMode && <span className="text-xs tabular-nums text-muted-foreground">{stepView.pos + 1} / {stepView.visibleIdx.length}</span>}
           </div>
           {neighboursMode ? (
-            <p className="ph-step">
+            <p className="truncate font-mono text-xs text-muted-foreground">
               {(neighbourhood?.nodes.size ?? 1) - 1} screen{(neighbourhood?.nodes.size ?? 1) - 1 === 1 ? '' : 's'} reachable
               in one action — highlighted with their edges
             </p>
           ) : (
             <>
-          <div className="ph-controls">
-            <button className="ph-replay" title="replay from the first step" onClick={() => setStep(stepView.effectiveEnd(0))} disabled={stepView.pos === 0}>↺</button>
-            <button onClick={() => setStep(stepView.effectiveEnd(Math.max(stepView.pos - 1, 0)))} disabled={stepView.pos === 0}>‹</button>
-            <div className="ph-dots">
+          <div className="flex items-center gap-2">
+            <Button variant="outline" size="icon" title="replay from the first step" onClick={() => setStep(stepView.effectiveEnd(0))} disabled={stepView.pos === 0}><RotateCcw /></Button>
+            <Button variant="outline" size="icon" onClick={() => setStep(stepView.effectiveEnd(Math.max(stepView.pos - 1, 0)))} disabled={stepView.pos === 0}><ChevronLeft /></Button>
+            <div className="flex flex-1 flex-wrap justify-center gap-1">
               {stepView.visibleIdx.map((si, k) => (
                 <button
                   key={si}
-                  className={`ph-dot ${k === stepView.pos ? 'now' : k < stepView.pos ? 'done' : ''}`}
+                  className={`size-3 rounded-full border-2 border-card transition-colors ${k === stepView.pos ? 'bg-primary ring-2 ring-primary/30' : k < stepView.pos ? 'bg-primary/60' : 'bg-muted-foreground/25'}`}
                   onClick={() => setStep(stepView.effectiveEnd(k))}
                   title={flow.steps[si].action}
                 />
               ))}
             </div>
-            <button
+            <Button
+              variant="outline"
+              size="icon"
               onClick={() => setStep(stepView.effectiveEnd(Math.min(stepView.pos + 1, stepView.visibleIdx.length - 1)))}
               disabled={stepView.pos === stepView.visibleIdx.length - 1}
-            >›</button>
+            ><ChevronRight /></Button>
           </div>
-          <div className="ph-step-row">
-            <p className="ph-step">
+          <div className="flex items-center gap-3 border-t pt-3">
+            <p className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground">
               {(() => {
                 const describe = (st) => {
                   if (st.action === 'open_url') return `deep link ${st.url}`
@@ -662,32 +683,32 @@ function Graph({ bundle, onOpenBuffer, onCloseDiff }) {
                   : `arrived — ${describe(stepView.visStep)}`
               })()}
             </p>
-            <button className="ph-copy" onClick={() => copyFlow(flow)}>Copy replay</button>
+            <Button size="sm" onClick={() => copyFlow(flow)}><Copy />Copy replay</Button>
           </div>
             </>
           )}
-        </footer>
+        </Card>
       )}
 
       {selectedDiffNode && !selectedEdge && (
-        <footer className="hud diff-card">
-          <div className="tc-route">
+        <Card className="absolute bottom-4 left-1/2 z-10 w-[min(560px,calc(100vw-320px))] -translate-x-1/2 gap-2 rounded-xl bg-card/95 px-4 py-4 shadow-2xl backdrop-blur-xl">
+          <div className="flex items-center gap-2 font-mono text-sm font-semibold">
             {selectedDiffNode.diff && (
-              <span className={`chg-badge chg-${selectedDiffNode.diff.status.toLowerCase()}`}>
+              <Badge variant="outline" className={`size-5 px-0 chg-${selectedDiffNode.diff.status.toLowerCase()}`}>
                 {selectedDiffNode.diff.status === 'A' ? '+' : selectedDiffNode.diff.status === 'D' ? '−' : '±'}
-              </span>
+              </Badge>
             )}
-            <span className="tc-screen">{selectedDiffNode.urlPath}</span>
-            <span className="dc-status">
+            <span className="truncate">{selectedDiffNode.urlPath}</span>
+            <span className="ml-auto shrink-0 font-sans text-xs font-normal text-muted-foreground">
               {selectedDiffNode.diff ? DIFF_LABEL[selectedDiffNode.diff.status] : 'unchanged in this diff'}
             </span>
           </div>
-          {selectedDiffNode.diff?.note && <p className="dc-note">{selectedDiffNode.diff.note}</p>}
+          {selectedDiffNode.diff?.note && <p className="text-sm leading-relaxed">{selectedDiffNode.diff.note}</p>}
           {selectedDiffNode.diff && (
-            <div className="tc-triggers">
-              <span className="tc-file">{selectedDiffNode.diff.reason}</span>
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="font-mono text-[11px] text-muted-foreground">{selectedDiffNode.diff.reason}</span>
               {(selectedDiffNode.diff.via ?? []).map((f) => (
-                <code key={f}>{f}</code>
+                <Badge key={f} variant="secondary" className="font-mono text-[10px]">{f}</Badge>
               ))}
             </div>
           )}
@@ -696,66 +717,69 @@ function Graph({ bundle, onOpenBuffer, onCloseDiff }) {
             const states = (diff.states ?? []).filter((s) => s.node === selectedDiffNode.id && marks[s.status])
             if (!states.length) return null
             return (
-              <div className="tc-triggers">
+              <div className="flex flex-wrap gap-1.5">
                 {states.map((s) => (
-                  <code key={s.name + s.status} className={`chg-${s.status.toLowerCase()}`} title={s.note ?? undefined}>
+                  <Badge key={s.name + s.status} variant="outline" className={`font-mono text-[10px] chg-${s.status.toLowerCase()}`} title={s.note ?? undefined}>
                     {marks[s.status]} {s.name === '' ? 'base screen' : s.name}
-                  </code>
+                  </Badge>
                 ))}
               </div>
             )
           })()}
-        </footer>
+        </Card>
       )}
 
       {selectedEdge && !flow && (
-        <footer className="hud transition-card">
-          <div className="tc-route">
+        <Card className="absolute bottom-4 left-1/2 z-10 w-[min(540px,calc(100vw-320px))] -translate-x-1/2 gap-2 rounded-xl bg-card/95 px-4 py-4 shadow-2xl backdrop-blur-xl">
+          <div className="flex items-center gap-2 font-mono text-sm font-semibold">
             {selectedEdge.diffStatus && (
-              <span className={`chg-badge chg-${selectedEdge.diffStatus.toLowerCase()}`}>
+              <Badge variant="outline" className={`size-5 px-0 chg-${selectedEdge.diffStatus.toLowerCase()}`}>
                 {selectedEdge.diffStatus === 'A' ? '+' : '−'}
-              </span>
+              </Badge>
             )}
-            <span className="tc-screen">{routeById[selectedEdge.from]?.urlPath ?? selectedEdge.from}</span>
-            <span className="tc-arrow">⟶</span>
-            <span className="tc-screen">{routeById[selectedEdge.to]?.urlPath ?? selectedEdge.to}</span>
+            <span className="truncate">{routeById[selectedEdge.from]?.urlPath ?? selectedEdge.from}</span>
+            <ChevronRight className="size-4 shrink-0 text-primary" />
+            <span className="truncate">{routeById[selectedEdge.to]?.urlPath ?? selectedEdge.to}</span>
           </div>
-          <div className="tc-triggers">
+          <div className="flex flex-wrap items-center gap-1.5">
             {selectedEdge.observed ? (
               <>
-                <span className="tc-file">not in static code analysis — observed by the agent in</span>
+                <span className="font-mono text-[11px] text-muted-foreground">not in static code analysis — observed by the agent in</span>
                 {selectedEdge.flows.slice(0, 3).map((f) => (
-                  <code key={f}>{f}</code>
+                  <Badge key={f} variant="secondary" className="font-mono text-[10px]">{f}</Badge>
                 ))}
                 {selectedEdge.flows.length > 3 && (
-                  <span className="tc-file">+{selectedEdge.flows.length - 3} more flows</span>
+                  <span className="font-mono text-[11px] text-muted-foreground">+{selectedEdge.flows.length - 3} more flows</span>
                 )}
               </>
             ) : (
               <>
                 {selectedEdge.raws.map((r) => (
-                  <code key={r}>{r}</code>
+                  <Badge key={r} variant="secondary" className="font-mono text-[10px]">{r}</Badge>
                 ))}
-                <span className="tc-file">in {routeById[selectedEdge.from]?.file}</span>
+                <span className="font-mono text-[11px] text-muted-foreground">in {routeById[selectedEdge.from]?.file}</span>
               </>
             )}
           </div>
-          <p className={`tc-note ${edgeGesture ? 'known' : ''}`}>
+          <p className={`text-xs ${edgeGesture ? 'text-cyan-400' : 'text-muted-foreground'}`}>
             {edgeGesture
               ? '◉ trigger position shown on the source screen'
               : 'trigger position not recorded — an interactive flow through this transition would pin it'}
           </p>
-        </footer>
+        </Card>
       )}
 
-      {commandSheet && (
-        <div className="sheet-scrim" onClick={() => setCommandSheet(null)}>
-          <div className="command-sheet" onClick={(e) => e.stopPropagation()}>
-            <h2>Replay · {commandSheet.flow.title ?? commandSheet.flow.name}</h2>
-            <pre>{commandSheet.cmd}</pre>
-            <div className="sheet-actions">
-              <button
-                className="copy-btn"
+      <Dialog open={!!commandSheet} onOpenChange={(open) => { if (!open) setCommandSheet(null) }}>
+        {commandSheet && (
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Replay · {commandSheet.flow.title ?? commandSheet.flow.name}</DialogTitle>
+              <DialogDescription>Run this command from the app workspace.</DialogDescription>
+            </DialogHeader>
+            <pre className="overflow-x-auto rounded-lg border bg-muted/60 p-4 font-mono text-xs leading-relaxed selection:bg-primary/30">{commandSheet.cmd}</pre>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setCommandSheet(null)}>Close</Button>
+              <Button
                 onClick={() =>
                   navigator.clipboard.writeText(commandSheet.cmd).then(
                     () => { showToast('Copied'); setCommandSheet(null) },
@@ -763,16 +787,15 @@ function Graph({ bundle, onOpenBuffer, onCloseDiff }) {
                   )
                 }
               >
-                Copy
-              </button>
-              <button className="ghost-btn" onClick={() => setCommandSheet(null)}>Close</button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      <div className={`toast ${toast ? 'show' : ''}`}>{toast}</div>
+                <Copy />Copy command
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        )}
+      </Dialog>
+      <Toaster theme="dark" position="top-center" toastOptions={{ className: 'border-border bg-popover text-popover-foreground' }} />
     </div>
+    </TooltipProvider>
   )
 }
 
@@ -885,40 +908,51 @@ export default function App() {
 
   return (
     <div
-      className={`landing ${dragging ? 'dragging' : ''}`}
+      className={`grid h-full place-items-center bg-background p-6 transition-colors ${dragging ? 'bg-primary/5' : ''}`}
       onDragOver={(e) => { e.preventDefault(); setDragging(true) }}
       onDragLeave={() => setDragging(false)}
       onDrop={onDrop}
     >
-      <div className="landing-card">
-        <span className="mark big" />
-        <h1>appmap visualiser</h1>
-        <p>Drop an <code>.appmap</code> bundle to explore your app as a living map — every screen, every link, every agent flow. Or drop an <code>.appmapdiff</code> to review what a PR changed.</p>
-        <label className="drop-zone">
-          <input
-            type="file"
-            accept=".appmap,.appmapdiff,.zip"
-            onChange={async (e) => {
-              const f = e.target.files?.[0]
-              if (f) open(await f.arrayBuffer())
-            }}
-          />
-          <span>{dragging ? 'drop it!' : 'drag a bundle here · or click to browse'}</span>
-        </label>
-        {demoAvailable && (
-          <button
-            className="demo-btn"
-            disabled={busy}
-            onClick={async () => {
-              const res = await fetch('/demo.appmap')
-              open(await res.arrayBuffer())
-            }}
-          >
-            {busy ? 'loading…' : 'load the demo bundle'}
-          </button>
-        )}
-        {error && <p className="error">{error}</p>}
-      </div>
+      <Card className="w-full max-w-lg gap-0 overflow-hidden border-border/80 bg-card/90 py-0 shadow-2xl backdrop-blur-xl">
+        <CardHeader className="items-center px-8 pb-5 pt-8 text-center">
+          <div className="mb-3 flex size-12 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-lg shadow-primary/20">
+            <MapIcon className="size-6" />
+          </div>
+          <CardTitle className="text-xl tracking-tight">Appmap visualiser</CardTitle>
+          <CardDescription className="max-w-md leading-relaxed">
+            Explore every screen, transition, and agent flow, or review the visual impact of a pull request.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3 px-8 pb-8">
+          <label className={`group flex min-h-36 cursor-pointer flex-col items-center justify-center gap-3 rounded-lg border border-dashed px-6 text-center transition-colors ${dragging ? 'border-primary bg-primary/10 text-primary' : 'border-border bg-muted/30 text-muted-foreground hover:border-primary/60 hover:bg-primary/5 hover:text-foreground'}`}>
+            <input
+              className="hidden"
+              type="file"
+              accept=".appmap,.appmapdiff,.zip"
+              onChange={async (e) => {
+                const f = e.target.files?.[0]
+                if (f) open(await f.arrayBuffer())
+              }}
+            />
+            <Upload className="size-5 transition-transform group-hover:-translate-y-0.5" />
+            <span className="text-sm font-medium">{dragging ? 'Drop bundle to open' : 'Drop an .appmap or .appmapdiff here'}</span>
+            <span className="text-xs text-muted-foreground">or click to browse</span>
+          </label>
+          {demoAvailable && (
+            <Button
+              className="w-full"
+              disabled={busy}
+              onClick={async () => {
+                const res = await fetch('/demo.appmap')
+                open(await res.arrayBuffer())
+              }}
+            >
+              <Sparkles />{busy ? 'Loading…' : 'Load demo bundle'}
+            </Button>
+          )}
+          {error && <p className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-xs text-destructive">{error}</p>}
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/apps/visualiser/src/components/ScreenNode.jsx
+++ b/apps/visualiser/src/components/ScreenNode.jsx
@@ -1,6 +1,9 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Handle, Position } from '@xyflow/react'
+import { ChevronDown } from 'lucide-react'
 import { visualDiff } from '../lib/visualDiff'
+import { Button } from './ui/button'
+import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuTrigger } from './ui/dropdown-menu'
 
 const BROKEN = {
   'error-boundary': { icon: '⛌', label: 'crashes on deep link' },
@@ -29,17 +32,6 @@ function StatusDot({ status }) {
 // dot (amber = changed, green = added, red = removed); the trigger shows the
 // active state's dot and lights up amber when any state changed.
 function StatePicker({ states, active, baseDiffStatus, onSelect }) {
-  const [open, setOpen] = useState(false)
-  const ref = useRef(null)
-  useEffect(() => {
-    if (!open) return
-    const close = (e) => {
-      if (!ref.current?.contains(e.target)) setOpen(false)
-    }
-    document.addEventListener('pointerdown', close)
-    return () => document.removeEventListener('pointerdown', close)
-  }, [open])
-
   const options = [
     { name: '', label: 'base screen', diff: baseDiffStatus },
     ...states.map((s) => ({ name: s.name, label: s.name, diff: s.diff ?? null })),
@@ -50,34 +42,38 @@ function StatePicker({ states, active, baseDiffStatus, onSelect }) {
 
   return (
     <div
-      ref={ref}
-      className={`state-picker nodrag nopan ${anyDiff ? 'has-diff' : ''} ${open ? 'open' : ''}`}
+      className="nodrag nopan mt-1.5 flex justify-center"
       onClick={(e) => e.stopPropagation()}
       onPointerDown={(e) => e.stopPropagation()}
     >
-      <button className="sp-trigger" onClick={() => setOpen((o) => !o)} title="switch displayed state">
-        <StatusDot status={current.diff} />
-        <span className="sp-label">{current.label}</span>
-        <span className="sp-chev">▾</span>
-      </button>
-      {open && (
-        <div className="sp-menu">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            className={`h-6 max-w-[148px] rounded-full bg-card/90 px-2 text-[10px] text-cyan-200 ${anyDiff ? 'border-amber-400/50 text-amber-300' : 'border-cyan-300/30'}`}
+            title="switch displayed state"
+          >
+            <StatusDot status={current.diff} />
+            <span className="truncate">{current.label}</span>
+            <ChevronDown className="size-3 opacity-60" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="center" className="min-w-36">
           {options.map((o) => (
-            <button
+            <DropdownMenuCheckboxItem
               key={o.name}
-              className={`sp-item ${o.name === activeName ? 'on' : ''}`}
+              checked={o.name === activeName}
               onClick={() => {
                 onSelect?.(o.name)
-                setOpen(false)
               }}
             >
-              <span className="sp-check">{o.name === activeName ? '✓' : ''}</span>
-              <span className="sp-label">{o.label}</span>
+              <span className="flex-1 truncate text-xs">{o.label}</span>
               <StatusDot status={o.diff} />
-            </button>
+            </DropdownMenuCheckboxItem>
           ))}
-        </div>
-      )}
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   )
 }

--- a/apps/visualiser/src/components/ui/badge.jsx
+++ b/apps/visualiser/src/components/ui/badge.jsx
@@ -1,0 +1,23 @@
+import { cva } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+
+const badgeVariants = cva(
+  'inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-md border px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-colors [&>svg]:size-3',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground',
+        destructive: 'border-transparent bg-destructive text-white',
+        outline: 'text-foreground',
+      },
+    },
+    defaultVariants: { variant: 'default' },
+  },
+)
+
+function Badge({ className, variant, ...props }) {
+  return <span data-slot="badge" className={cn(badgeVariants({ variant }), className)} {...props} />
+}
+
+export { Badge }

--- a/apps/visualiser/src/components/ui/button.jsx
+++ b/apps/visualiser/src/components/ui/button.jsx
@@ -1,0 +1,33 @@
+import { Slot } from '@radix-ui/react-slot'
+import { cva } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+
+const buttonVariants = cva(
+  'inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',
+        destructive: 'bg-destructive text-white shadow-xs hover:bg-destructive/90',
+        outline: 'border border-border bg-background/70 shadow-xs hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+      },
+      size: {
+        default: 'h-9 px-4 py-2',
+        sm: 'h-8 rounded-md gap-1.5 px-3 text-xs',
+        lg: 'h-10 rounded-md px-6',
+        icon: 'size-9',
+        'icon-sm': 'size-8',
+      },
+    },
+    defaultVariants: { variant: 'default', size: 'default' },
+  },
+)
+
+function Button({ className, variant, size, asChild = false, ...props }) {
+  const Comp = asChild ? Slot : 'button'
+  return <Comp data-slot="button" className={cn(buttonVariants({ variant, size, className }))} {...props} />
+}
+
+export { Button }

--- a/apps/visualiser/src/components/ui/card.jsx
+++ b/apps/visualiser/src/components/ui/card.jsx
@@ -1,0 +1,27 @@
+import { cn } from '@/lib/utils'
+
+function Card({ className, ...props }) {
+  return <div data-slot="card" className={cn('flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm', className)} {...props} />
+}
+
+function CardHeader({ className, ...props }) {
+  return <div data-slot="card-header" className={cn('grid gap-1.5 px-6', className)} {...props} />
+}
+
+function CardTitle({ className, ...props }) {
+  return <div data-slot="card-title" className={cn('font-semibold leading-none', className)} {...props} />
+}
+
+function CardDescription({ className, ...props }) {
+  return <div data-slot="card-description" className={cn('text-sm text-muted-foreground', className)} {...props} />
+}
+
+function CardContent({ className, ...props }) {
+  return <div data-slot="card-content" className={cn('px-6', className)} {...props} />
+}
+
+function CardFooter({ className, ...props }) {
+  return <div data-slot="card-footer" className={cn('flex items-center px-6', className)} {...props} />
+}
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter }

--- a/apps/visualiser/src/components/ui/dialog.jsx
+++ b/apps/visualiser/src/components/ui/dialog.jsx
@@ -1,0 +1,46 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+const Dialog = DialogPrimitive.Root
+const DialogTrigger = DialogPrimitive.Trigger
+const DialogClose = DialogPrimitive.Close
+
+function DialogContent({ className, children, showCloseButton = true, ...props }) {
+  return (
+    <DialogPrimitive.Portal>
+      <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/65 backdrop-blur-sm data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn('fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl border bg-popover p-6 text-popover-foreground shadow-2xl duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95', className)}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring disabled:pointer-events-none">
+            <X />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPrimitive.Portal>
+  )
+}
+
+function DialogHeader({ className, ...props }) {
+  return <div className={cn('flex flex-col gap-2 text-left', className)} {...props} />
+}
+
+function DialogFooter({ className, ...props }) {
+  return <div className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)} {...props} />
+}
+
+function DialogTitle({ className, ...props }) {
+  return <DialogPrimitive.Title className={cn('text-lg font-semibold leading-none', className)} {...props} />
+}
+
+function DialogDescription({ className, ...props }) {
+  return <DialogPrimitive.Description className={cn('text-sm text-muted-foreground', className)} {...props} />
+}
+
+export { Dialog, DialogTrigger, DialogClose, DialogContent, DialogHeader, DialogFooter, DialogTitle, DialogDescription }

--- a/apps/visualiser/src/components/ui/dropdown-menu.jsx
+++ b/apps/visualiser/src/components/ui/dropdown-menu.jsx
@@ -1,0 +1,46 @@
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
+import { Check } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+
+function DropdownMenuContent({ className, sideOffset = 4, ...props }) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn('z-50 min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95', className)}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuItem({ className, inset, ...props }) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      className={cn('relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50', inset && 'pl-8', className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({ className, children, checked, ...props }) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      checked={checked}
+      className={cn('relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground', className)}
+      {...props}
+    >
+      <span className="absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator><Check className="size-4" /></DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+export { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuCheckboxItem }

--- a/apps/visualiser/src/components/ui/tooltip.jsx
+++ b/apps/visualiser/src/components/ui/tooltip.jsx
@@ -1,0 +1,20 @@
+import * as TooltipPrimitive from '@radix-ui/react-tooltip'
+import { cn } from '@/lib/utils'
+
+const TooltipProvider = TooltipPrimitive.Provider
+const Tooltip = TooltipPrimitive.Root
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+function TooltipContent({ className, sideOffset = 6, ...props }) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        sideOffset={sideOffset}
+        className={cn('z-50 rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground shadow-md data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0', className)}
+        {...props}
+      />
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/apps/visualiser/src/index.css
+++ b/apps/visualiser/src/index.css
@@ -1,17 +1,66 @@
+@import "tailwindcss";
+@import "tw-animate-css";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted-surface);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+}
+
 :root {
-  --bg: #0a0c11;
-  --panel: rgba(17, 20, 28, 0.72);
+  --radius: 0.625rem;
+  --background: oklch(0.13 0.01 270);
+  --foreground: oklch(0.97 0.005 270);
+  --card: oklch(0.18 0.012 270);
+  --card-foreground: oklch(0.97 0.005 270);
+  --popover: oklch(0.19 0.012 270);
+  --popover-foreground: oklch(0.97 0.005 270);
+  --primary: oklch(0.67 0.18 266);
+  --primary-foreground: oklch(0.98 0.01 266);
+  --secondary: oklch(0.25 0.015 270);
+  --secondary-foreground: oklch(0.97 0.005 270);
+  --muted-surface: oklch(0.23 0.012 270);
+  --muted-foreground: oklch(0.7 0.02 270);
+  --accent: oklch(0.27 0.025 270);
+  --accent-foreground: oklch(0.98 0.005 270);
+  --destructive: oklch(0.65 0.2 25);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 14%);
+  --ring: oklch(0.67 0.18 266);
+  --bg: var(--background);
+  --panel: oklch(0.18 0.012 270 / 88%);
   --panel-border: rgba(255, 255, 255, 0.08);
-  --fg: #e8eaf0;
-  --muted: #8b93a7;
-  --accent: #818cf8;
-  --accent-bright: #a5b4fc;
+  --fg: var(--foreground);
+  --muted: var(--muted-foreground);
+  --map-accent: #818cf8;
+  --map-accent-bright: #a5b4fc;
   --warn: #f59e0b;
   --ease: cubic-bezier(0.2, 0, 0, 1);
   color-scheme: dark;
 }
 
-* { box-sizing: border-box; }
+* { box-sizing: border-box; border-color: var(--border); }
 
 html, body, #root { height: 100%; margin: 0; }
 
@@ -21,7 +70,7 @@ body {
     radial-gradient(900px 600px at 100% 110%, rgba(34, 211, 238, 0.07), transparent 60%),
     var(--bg);
   color: var(--fg);
-  font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", sans-serif;
+  font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   -webkit-font-smoothing: antialiased;
   overflow: hidden;
 }
@@ -93,9 +142,9 @@ button, .drop-zone, .label, .badge-row, .state-tag, .flow-group, .stats, .brand,
   transition-duration: 0.25s;
 }
 .drop-zone:hover, .landing.dragging .drop-zone {
-  border-color: var(--accent);
+  border-color: var(--map-accent);
   background-color: rgba(129, 140, 248, 0.07);
-  color: var(--accent-bright);
+  color: var(--map-accent-bright);
 }
 .drop-zone input { display: none; }
 
@@ -441,7 +490,7 @@ button, .drop-zone, .label, .badge-row, .state-tag, .flow-group, .stats, .brand,
   transition-property: stroke; transition-duration: 0.2s; }
 .edge-faded .react-flow__edge-path { stroke: rgba(255, 255, 255, 0.045); }
 .edge-on-path .react-flow__edge-path {
-  stroke: var(--accent-bright);
+  stroke: var(--map-accent-bright);
   stroke-width: 2.4;
   filter: drop-shadow(0 0 6px rgba(129, 140, 248, 0.55));
 }
@@ -666,7 +715,7 @@ button, .drop-zone, .label, .badge-row, .state-tag, .flow-group, .stats, .brand,
 }
 .ph-dot.done::after { background: rgba(129, 140, 248, 0.55); }
 .ph-dot.now::after {
-  background: var(--accent-bright);
+  background: var(--map-accent-bright);
   box-shadow: 0 0 10px rgba(129, 140, 248, 0.8);
 }
 .ph-step-row { display: flex; align-items: center; gap: 10px; margin-top: 4px; }
@@ -709,7 +758,7 @@ button, .drop-zone, .label, .badge-row, .state-tag, .flow-group, .stats, .brand,
   font-weight: 600;
 }
 .tc-screen { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.tc-arrow { color: var(--accent-bright); flex: none; }
+.tc-arrow { color: var(--map-accent-bright); flex: none; }
 .tc-triggers {
   display: flex;
   flex-wrap: wrap;
@@ -722,7 +771,7 @@ button, .drop-zone, .label, .badge-row, .state-tag, .flow-group, .stats, .brand,
   border-radius: 8px;
   background: rgba(129, 140, 248, 0.12);
   border: 1px solid rgba(129, 140, 248, 0.3);
-  color: var(--accent-bright);
+  color: var(--map-accent-bright);
   font-size: 11px;
 }
 .tc-file { color: var(--muted); font-size: 10.5px; font-family: ui-monospace, Menlo, monospace; }
@@ -736,6 +785,10 @@ button, .drop-zone, .label, .badge-row, .state-tag, .flow-group, .stats, .brand,
   --diff-m: #fbbf24;
   --diff-d: #f87171;
 }
+
+.chg-a { color: var(--diff-a); border-color: hsl(158 64% 52% / 0.35); background: hsl(158 64% 52% / 0.08); }
+.chg-m { color: var(--diff-m); border-color: hsl(43 96% 56% / 0.35); background: hsl(43 96% 56% / 0.08); }
+.chg-d { color: var(--diff-d); border-color: hsl(0 91% 71% / 0.35); background: hsl(0 91% 71% / 0.08); }
 
 .screen-node.diff-unchanged { opacity: 0.38; filter: saturate(0.55); }
 .screen-node.diff-unchanged:hover,
@@ -807,7 +860,7 @@ button, .drop-zone, .label, .badge-row, .state-tag, .flow-group, .stats, .brand,
   border-radius: 99px;
   background: rgba(129, 140, 248, 0.14);
   border: 1px solid rgba(129, 140, 248, 0.4);
-  color: var(--accent-bright);
+  color: var(--map-accent-bright);
   font-size: 10.5px;
   font-weight: 700;
   vertical-align: 2px;
@@ -883,7 +936,7 @@ button, .drop-zone, .label, .badge-row, .state-tag, .flow-group, .stats, .brand,
   background: rgba(17, 20, 28, 0.9);
   backdrop-filter: blur(16px);
   border: 1px solid rgba(129, 140, 248, 0.4);
-  color: var(--accent-bright);
+  color: var(--map-accent-bright);
   font-size: 12.5px;
   font-weight: 600;
   opacity: 0;

--- a/apps/visualiser/src/lib/utils.js
+++ b/apps/visualiser/src/lib/utils.js
@@ -1,0 +1,6 @@
+import { clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs) {
+  return twMerge(clsx(inputs))
+}

--- a/apps/visualiser/vite.config.js
+++ b/apps/visualiser/vite.config.js
@@ -1,7 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+import { fileURLToPath, URL } from 'node:url'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- add shadcn configuration, Tailwind v4 theming, shared UI primitives, and Lucide icons
- rebuild the visualiser header, flow sidebar, playback controls, diff details, bundle landing state, dialogs, tooltips, and toast feedback with shadcn components
- replace the custom node state picker with a Radix-backed shadcn dropdown while preserving graph and diff behavior
- resolve the existing unstable memo dependencies surfaced by lint

## Verification
- `npm ci`
- `npm run lint`
- `npm run build`
- visually verified map loading, flow selection/playback, copy feedback, and diff detail mode in Chromium