### PR TITLE
harden: github actions step uses a mutable tag or branc... in...

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -183,7 +183,7 @@ runs:
 
     - name: Upload artifact
       if: steps.run.outputs.bundle != ''
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v4.4.3
       with:
         name: appmap-${{ inputs.mode }}-${{ github.run_id }}
         path: |


### PR DESCRIPTION
## Summary
Harden input handling in `action.yml` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag` |
| **File** | `action.yml:186` |
| **Assessment** | Defensive hardening |

**Description**: GitHub Actions step uses a mutable tag or branch reference. Tags and branch names can be silently repointed by the action owner, enabling supply-chain attacks — as seen in the trivy-action and kics-github-action compromises. Pin the reference to a full 40-character commit SHA instead, e.g. `uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608`.

## Changes
- `action.yml`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
