### PR TITLE
Route providers: make react-navigation a first-class producer

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ The expensive part is step 2, and you only pay it once. Recorded flows get commi
 
 - `plugins/screenmap/skills/screenmap/SKILL.md` is the agent orchestration: phases, safety rails, and the flow-recording contract.
 - `plugins/screenmap/skills/screenmap/scripts/` holds `parse-routes.mjs`, `pack-map.mjs`, `diff-map.mjs` (PR diff: suspects and pack) and `render-map.mjs` (static HTML fallback). All plain Node, no dependencies.
+- `plugins/screenmap/skills/screenmap/scripts/routes/` is the route-provider layer: `parse-routes.mjs` only drives it, and each framework (expo-router, react-navigation, or a command you supply) is one module under `providers/`. See [docs/route-providers.md](docs/route-providers.md) to add one.
 - `apps/visualiser/` is the Map / Changes viewer, built with Vite, React, Tailwind v4, shadcn/ui, React Flow and elkjs, plus pixelmatch and OpenCV.js for the visual diff.
 - `action.yml` is the composite GitHub Action. The metadata sits at the repo root so the repo is publishable to the Marketplace. Its `screenmap-ci` CLI lives in `action/cli`, and the workflow and `.scrmap` templates live in `action/templates`.
 - [`docs/scrmap-format.md`](docs/scrmap-format.md) is the versioned bundle format contract, for writing your own producer.

--- a/action/cli/lib/agent.mjs
+++ b/action/cli/lib/agent.mjs
@@ -106,12 +106,12 @@ export function runAgent({ projectDir, config, screens, scheme, udid, bundleId, 
 Read the skill at ${SKILL_DIR}/SKILL.md for conventions (capture naming, flow recording format, safety rules: never tap destructive/purchase/sign-out controls, never record credentials). The project lives at ${projectDir}. All output paths below are absolute — write to them exactly.
 ${repoSkillText ? `\nProject-specific guidance (.screenmap/SKILL.md) — follow it:\n---\n${repoSkillText}\n---\n` : ''}
 Task (${mode}): for EACH of these screens, capture the screen and record a replayable navigation flow.
-${budgeted.map((s) => `- ${s.id}  urlPath=${s.urlPath}  slug=${s.slug}  deepLink=${s.deepLink}  file=${s.file ?? '?'}${s.reason ? `  why=${s.reason}` : ''}`).join('\n')}
+${budgeted.map((s) => `- ${s.id}  ${s.deepLink ? `urlPath=${s.urlPath}  deepLink=${s.deepLink}` : 'NO DEEP LINK — reach it by tapping from app launch'}  slug=${s.slug}  file=${s.file ?? '?'}${s.reason ? `  why=${s.reason}` : ''}`).join('\n')}
 
 Rules:
 1. Screenshots go to ${outScreensDir}/<slug>.png (state variants: <slug>--<state>.png). Use exactly these slugs.
 2. Flows go to ${outFlowsDir}/ as argent YAML + .meta.json sidecars (formatVersion 2) — nav-<slug> for the tap path from app launch (\`${scheme}://\`), visit-<slug> for the bare deep link, plus one flow per state variant you capture. Coordinates normalized 0–1 for a ${config.device}. Every sidecar MUST include \`"landmarks": [2–5 words visible on the arrival screen that identify it — titles/section headers/fixed labels, never live content]\`; CI verifies replays by OCR-ing for them.
-3. Prefer the deep link first; if it shows an error/not-found, find real params (public API, other screens) and note what you used.
+3. Prefer the deep link first; if it shows an error/not-found, find real params (public API, other screens) and note what you used. A screen marked NO DEEP LINK has no URL at all — do NOT open \`${scheme}://\` and screenshot whatever appears, which would file the home screen under its name. Navigate to it by tapping, and let its nav flow be its capture.
 4. Write ${notesPath}: JSON { "<routeId>": "one sentence describing what this screen shows${mode === 'pr' ? ' / what visibly changed in this PR' : ''}" } for each screen you handled${mode === 'pr' ? ', or { "note": "...", "verdict": "unaffected" } if the PR diff shows no visible change there' : ''}.
 5. Write ${summaryPath}: JSON { "captured": [routeIds], "skipped": [{ "id", "why" }], "flows": [flow names] } when done.
 6. Budget: these ${budgeted.length} screens only. Be economical — no broad exploration.${prContext ? `\n\nPR context: ${prContext}` : ''}`

--- a/action/cli/lib/bundle.mjs
+++ b/action/cli/lib/bundle.mjs
@@ -28,7 +28,9 @@ export function graphFromMap(manifest, map) {
   return {
     generatedAt: manifest.generatedAt, projectRoot: null, scheme: manifest.app?.scheme ?? null, mode: manifest.app?.mode ?? null,
     routes: map.nodes.map((n) => ({
-      id: n.id, file: n.file, urlPath: n.urlPath, slug: n.slug, params: n.params ?? [], navigator: n.navigator,
+      id: n.id, file: n.file, urlPath: n.urlPath ?? null, slug: n.slug, params: n.params ?? [], navigator: n.navigator,
+      title: n.title ?? n.urlPath ?? n.id,
+      reach: n.reach ?? (n.urlPath ? 'deep-link' : 'navigation-only'),
       layoutDir: n.group ?? '', presentation: n.presentation ?? null, stateHints: n.stateHints ?? [],
     })),
     edges: map.edges ?? [],
@@ -69,9 +71,11 @@ export function packBaseline({ graph, screensDir, flowsDir, captureStatus = {}, 
     const baseShot = shotFiles.find((f) => f.replace(/\.\w+$/, '') === r.slug)
     const states = shotFiles.filter((f) => f.startsWith(r.slug + '--')).map((f) => ({ name: f.replace(/\.\w+$/, '').slice(r.slug.length + 2), screenshot: 'screens/' + f })).sort((a, b) => a.name.localeCompare(b.name))
     return {
-      id: r.id, urlPath: r.urlPath, file: r.file ?? null, slug: r.slug, group: r.layoutDir ?? '', navigator: r.navigator ?? null,
+      id: r.id, urlPath: r.urlPath ?? null, title: r.title ?? r.urlPath ?? r.id,
+      reach: r.reach ?? (r.urlPath ? 'deep-link' : 'navigation-only'),
+      file: r.file ?? null, slug: r.slug, group: r.layoutDir ?? '', navigator: r.navigator ?? null,
       params: r.params ?? [], presentation: r.presentation ?? null, stateHints: r.stateHints ?? [],
-      capture: { status: cs.status ?? (baseShot ? 'ok' : 'missing'), note: cs.note ?? null, needsNavigation: cs.needsNavigation ?? false, screenshot: baseShot ? 'screens/' + baseShot : null, states },
+      capture: { status: cs.status ?? (baseShot ? 'ok' : 'missing'), note: cs.note ?? null, needsNavigation: cs.needsNavigation ?? r.reach === 'navigation-only', screenshot: baseShot ? 'screens/' + baseShot : null, states },
     }
   })
   const map = { nodes, edges: graph.edges ?? [], flows: [] }

--- a/action/cli/lib/util.mjs
+++ b/action/cli/lib/util.mjs
@@ -81,6 +81,9 @@ export function loadConfig(projectDir) {
     suspects: { broadCap: 8 },
     agent: { enabled: true, model: null, provider: null, command: null, keyEnv: null },
     flowsDir: '.screenmap/flows', skillFile: '.screenmap/SKILL.md',
+    // routes.provider pins the route provider when detection is ambiguous or
+    // wrong; "custom" runs routes.command instead. See docs/route-providers.md.
+    routes: { provider: 'auto', command: null },
     params: {},
   }
   const user = readJson(path.join(projectDir, '.screenmap', 'config.json'), {})
@@ -100,6 +103,7 @@ export function loadConfig(projectDir) {
     waits: { ...defaults.waits, ...(user.waits ?? {}) },
     suspects: { ...defaults.suspects, ...(user.suspects ?? {}) },
     agent: { ...defaults.agent, ...(user.agent ?? {}) },
+    routes: { ...defaults.routes, ...(user.routes ?? {}) },
   }
   if (process.env.AGENT_MAX_SCREENS) merged.agent.maxScreens = Number(process.env.AGENT_MAX_SCREENS) || merged.agent.maxScreens
   if (process.env.SCREENMAP_APP_PATH) merged.appPath = process.env.SCREENMAP_APP_PATH // a prebuilt client (e.g. from EAS) beats ios/build discovery
@@ -107,8 +111,12 @@ export function loadConfig(projectDir) {
 }
 
 // substitute :param placeholders in a urlPath with sample values
+// null when the route has no URL at all. Navigator-driven frameworks register
+// plenty of screens outside their linking config; falling back to the app root
+// would capture the home screen and file it under this route's name.
 export function deepLinkFor(scheme, route, params = {}) {
-  let p = route.urlPath ?? '/'
+  if (!route.urlPath) return null
+  let p = route.urlPath
   for (const name of route.params ?? []) {
     const v = params[`${route.id}.${name}`] ?? params[name] ?? '1'
     p = p.replace(new RegExp(`:${name}\\??`, 'g'), encodeURIComponent(String(v))).replace(new RegExp(`\\[${name}\\]`, 'g'), encodeURIComponent(String(v)))

--- a/action/cli/screenmap-ci.mjs
+++ b/action/cli/screenmap-ci.mjs
@@ -45,7 +45,7 @@ const copyShots = (fromDir, toDir, slug) => {
 // Capture a list of routes on the live session: committed flow replay first,
 // deep link otherwise, agent for what's left (budgeted). Shared by both jobs.
 async function captureRoutes({ project, config, scheme, session, routes, flows, outDir, work, agentMode, prContext, agentEnabled }) {
-  const result = { replay: [], deeplink: [], agent: [], failed: [], unflowed: [], drifted: [], unverified: [] }
+  const result = { replay: [], deeplink: [], agent: [], failed: [], unflowed: [], drifted: [], unverified: [], navigationOnly: [] }
   const canReplay = flows.size > 0 && argentAvailable()
   if (flows.size > 0 && !canReplay) log('argent not available — committed flows will not be replayed this run')
   for (const r of routes) {
@@ -65,7 +65,7 @@ async function captureRoutes({ project, config, scheme, session, routes, flows, 
         const primary = f.nav ?? f.visit ?? recs[0]
         const v = await verifyLanding({
           shot, rec: primary, udid: session.udid,
-          probe: async () => { try { await session.relaunch(); const p = path.join(work, 'tmp', `${r.slug}.deeplink.png`); await session.visit(deepLinkFor(scheme, r, config.params), p, r.params?.length ? config.waits.network : config.waits.transition); return p } catch { return null } },
+          probe: async () => { const link = deepLinkFor(scheme, r, config.params); if (!link) return null; try { await session.relaunch(); const p = path.join(work, 'tmp', `${r.slug}.deeplink.png`); await session.visit(link, p, r.params?.length ? config.waits.network : config.waits.transition); return p } catch { return null } },
         })
         if (v.ok) { result.replay.push(r.id); done = true; log(`replay ${primary.name} ✓ (${v.method}${v.score != null ? ` ${v.score}` : ''})`) }
         else {
@@ -81,7 +81,13 @@ async function captureRoutes({ project, config, scheme, session, routes, flows, 
         await session.relaunch()
       }
     }
-    if (!done) {
+    if (!done && !deepLinkFor(scheme, r, config.params)) {
+      // No URL means no deep link. Hand it to the agent, which reaches it by
+      // tapping, rather than visiting the app root and filing the home screen
+      // under this route's name.
+      result.navigationOnly.push(r.id)
+      result.unflowed.push({ ...r, reason: (r.reason ? r.reason + '; ' : '') + 'no deep link — reachable only by in-app navigation' })
+    } else if (!done) {
       try {
         const wait = (r.params?.length ? config.waits.network : config.waits.transition)
         const shot = path.join(outDir, `${r.slug}.png`)
@@ -179,7 +185,7 @@ async function baseline() {
   if (!scheme) throw new Error('no deep-link scheme: set scheme in .screenmap/config.json')
   const commit = opts.commit ?? git(['rev-parse', 'HEAD'], project)
   const ref = opts.ref ?? git(['rev-parse', '--abbrev-ref', 'HEAD'], project)
-  const appName = config.appName ?? path.basename(project)
+  const appName = config.appName ?? graph.appName ?? path.basename(project)
   const screensDir = ensureDir(path.join(work, 'screens'))
   let captureStatus = {}
 
@@ -248,7 +254,7 @@ async function pr() {
   const scheme = config.scheme ?? headGraph.scheme ?? base.graph.scheme
   const baseSha = opts.base ?? base.manifest.source?.commit ?? null
   const headSha = opts.head ?? git(['rev-parse', 'HEAD'], project)
-  const appName = config.appName ?? base.manifest.app?.name ?? path.basename(project)
+  const appName = config.appName ?? headGraph.appName ?? base.manifest.app?.name ?? path.basename(project)
   let changed = opts['changed-files'] ? fs.readFileSync(opts['changed-files'], 'utf8').split('\n').filter(Boolean) : null
   if (!changed && baseSha) changed = (git(['diff', '--name-only', `${baseSha}...${headSha}`], project) ?? git(['diff', '--name-only', baseSha, headSha], project) ?? '').split('\n').filter(Boolean)
   if (!changed) throw new Error('cannot determine changed files: pass --changed-files <list> or make sure the base commit is fetched')
@@ -301,7 +307,7 @@ async function pr() {
     // base first so head wins on collision: a removed route only exists on the
     // base side, and without it the comment prints its bare id ("grind")
     // where every other row shows a path ("/grind")
-    routes: Object.fromEntries([...base.graph.routes, ...headGraph.routes].map((r) => [r.id, r.urlPath])),
+    routes: Object.fromEntries([...base.graph.routes, ...headGraph.routes].map((r) => [r.id, r.title ?? r.urlPath ?? r.id])),
     shots: collectShots(diffDir, [...headGraph.routes, ...base.graph.routes], [...diff.nodes.map((d) => d.id), ...(diff.dismissed ?? []).map((d) => d.id)]),
   }
   writeJson(path.join(work, 'summary.json'), summary)

--- a/apps/visualiser/src/components/Graph.jsx
+++ b/apps/visualiser/src/components/Graph.jsx
@@ -8,6 +8,7 @@ import { Playhead, TransitionCard, ChangeCard, CommandSheet } from './Dock'
 import { flowResolution, isInteractive } from '../lib/loadBundle'
 import { layoutGraph, NODE_H, NODE_W } from '../lib/layout'
 import { flowForNode, replayCommand } from '../lib/replay'
+import { nodeLabel } from '../lib/label.js'
 
 const nodeTypes = { screen: ScreenNode }
 
@@ -418,7 +419,7 @@ export default function Graph({ bundle, mode, setMode, hasChanges, overlaid, onO
   const panelItems = diffMode
     ? diff.nodes.map((d) => ({
         key: d.id, kind: d.status, mono: true, active: selectedNode === d.id, title: d.note ?? d.reason,
-        label: routeById[d.id]?.urlPath ?? d.id,
+        label: nodeLabel(routeById[d.id], d.id),
         onClick: () => { setSelectedEdge(null); setSelectedNode(d.id); focusNode(d.id) },
       }))
     : interactiveFlows.map((f) => ({
@@ -525,7 +526,7 @@ export default function Graph({ bundle, mode, setMode, hasChanges, overlaid, onO
       {flow && stepView && (
         <Playhead
           title={flow.title ?? flow.name}
-          subjectPath={routeById[subjectId]?.urlPath ?? subjectId}
+          subjectPath={nodeLabel(routeById[subjectId], subjectId)}
           neighbours={neighboursMode}
           neighbourCount={neighbourCount}
           onShowNeighbours={() => setNeighboursMode(true)}
@@ -545,7 +546,7 @@ export default function Graph({ bundle, mode, setMode, hasChanges, overlaid, onO
 
       {selectedDiffNode && !selectedEdge && !flow && (
         <ChangeCard
-          urlPath={selectedDiffNode.urlPath}
+          urlPath={nodeLabel(selectedDiffNode)}
           diff={selectedDiffNode.diff}
           states={(diff.states ?? []).filter((s) => s.node === selectedDiffNode.id && ['A', 'M', 'D'].includes(s.status))}
         />
@@ -553,8 +554,8 @@ export default function Graph({ bundle, mode, setMode, hasChanges, overlaid, onO
 
       {selectedEdge && !flow && (
         <TransitionCard
-          from={routeById[selectedEdge.from]?.urlPath ?? selectedEdge.from}
-          to={routeById[selectedEdge.to]?.urlPath ?? selectedEdge.to}
+          from={nodeLabel(routeById[selectedEdge.from], selectedEdge.from)}
+          to={nodeLabel(routeById[selectedEdge.to], selectedEdge.to)}
           diffStatus={selectedEdge.diffStatus}
           observed={!!selectedEdge.observed}
           flows={selectedEdge.flows ?? []}

--- a/apps/visualiser/src/components/ScreenNode.jsx
+++ b/apps/visualiser/src/components/ScreenNode.jsx
@@ -4,6 +4,7 @@ import { Check, ChevronDown } from 'lucide-react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { visualDiff } from '../lib/visualDiff'
 import { cn } from '@/lib/utils'
+import { nodeLabel } from '../lib/label.js'
 
 const BROKEN = {
   'error-boundary': { icon: '⛌', label: 'crashes on deep link' },
@@ -127,7 +128,7 @@ export default function ScreenNode({ data, selected }) {
         onMouseLeave={canSwap ? () => setHovered(false) : undefined}
       >
         {displayed ? (
-          <img src={displayed} alt={node.urlPath} draggable={false} />
+          <img src={displayed} alt={nodeLabel(node)} draggable={false} />
         ) : (
           <div className="no-shot"><span>{node.capture.status === 'missing' ? 'no capture' : node.capture.status}</span></div>
         )}
@@ -163,7 +164,7 @@ export default function ScreenNode({ data, selected }) {
       </div>
       <div className="node-label">
         <span className="dot" />
-        <span className="path" title={node.file ?? ''}>{node.urlPath}</span>
+        <span className="path" title={node.file ?? ''}>{nodeLabel(node)}</span>
       </div>
       {states.length === 0 ? null : statePickable ? (
         <StatePicker states={states} active={activeState} baseDiffStatus={baseDiffStatus} onSelect={onStateSelect} />

--- a/apps/visualiser/src/lib/label.js
+++ b/apps/visualiser/src/lib/label.js
@@ -1,0 +1,8 @@
+// What to call a screen on the map.
+//
+// Not every framework gives every screen a URL: a react-navigation screen that
+// is registered on a navigator but absent from the linking config has no path
+// at all. `title` is the producer's own label and is always present in bundles
+// packed after the route-provider split; the fallbacks keep older bundles
+// rendering exactly as they did before.
+export const nodeLabel = (n, fallback = '?') => n?.title ?? n?.urlPath ?? n?.id ?? fallback

--- a/docs/route-providers.md
+++ b/docs/route-providers.md
@@ -1,0 +1,176 @@
+# Route providers
+
+A **route provider** is the part of screenmap that knows how one framework
+declares its screens. Everything downstream — capture, packing, diffing, the
+viewer — consumes one graph shape and never learns which framework produced it.
+
+```
+plugins/screenmap/skills/screenmap/scripts/
+  parse-routes.mjs          driver: detect → select → parse → normalize → validate → emit
+  routes/
+    registry.mjs            the provider list and the selection rules
+    lib/project.mjs         walking, tsconfig aliases, import following, app config
+    lib/hints.mjs           runtime-state hints (bottom sheets, modals)
+    lib/graph.mjs           defaults, orphan detection, summary, validation
+    providers/
+      expo-router.mjs
+      react-navigation.mjs
+      custom.mjs
+```
+
+Shipped providers:
+
+| id | what it reads | reach |
+|---|---|---|
+| `expo-router` | the `app/` route tree | `deep-link` — the file path *is* the URL |
+| `react-navigation` | `<X.Screen>` registrations + the linking config | `mixed` — a screen has a URL only if the linking config gives it one |
+| `custom` | a command you supply | `unknown` |
+
+## Choosing a provider
+
+By default the driver asks every provider to score the project and picks the
+winner:
+
+```bash
+node scripts/parse-routes.mjs .            # detect and parse
+node scripts/parse-routes.mjs . --detect   # show the scores, parse nothing
+node scripts/parse-routes.mjs . --provider react-navigation
+node scripts/parse-routes.mjs . --list-providers
+```
+
+```
+0.95  expo-router        app/ contains a _layout route; expo-router in package.json
+0.00  react-navigation   expo-router also present — deferring to it
+0.00  custom             opt-in only: set routes.provider = "custom"
+```
+
+Scores rather than booleans, because the frameworks genuinely overlap: an
+expo-router app *uses* react-navigation underneath, and plenty of
+react-navigation apps keep their source in `app/`. Two things follow:
+
+- a provider below **0.4** is guessing, and the driver refuses rather than parse
+  with the wrong one;
+- two providers within **0.15** of each other are a tie, and the driver asks you
+  to break it instead of picking silently.
+
+Pin the choice in `.screenmap/config.json` when detection is wrong, or when you
+want a repo to stop depending on detection at all:
+
+```jsonc
+{ "routes": { "provider": "react-navigation" } }
+```
+
+## The graph contract
+
+A provider returns a fragment; `lib/graph.mjs` fills in the rest.
+
+```jsonc
+{
+  "routes": [{
+    "id": "Profile",              // required, unique
+    "slug": "Profile",            // required, unique, filename-safe (screenshots are <slug>.png,
+                                  //   so no "/" and no "--")
+    "title": "Profile",           // human label; defaults to urlPath ?? id
+    "urlPath": "/profile/:id",    // null when the screen has no URL
+    "reach": "deep-link",         // "deep-link" | "navigation-only" | "unknown";
+                                  //   defaults from whether urlPath is set
+    "file": "src/screens/Profile.tsx",
+    "params": ["id"],
+    "navigator": "Stack",         // Stack | Tabs | TopTabs | Drawer | Slot | null
+    "layoutDir": "Stack",         // grouping key; becomes `group` in the bundle
+    "presentation": "modal",
+    "stateHints": []
+  }],
+  "edges": [{ "from": "Feed", "to": "Profile", "raw": "navigate('Profile')", "target": "/profile/:id" }],
+  "layouts": [{ "file": "src/navigation/RootNavigator.tsx", "dir": "Tabs", "navigator": "Tabs" }]
+}
+```
+
+Any other top-level key rides along into `graph.json` as a diagnostic —
+`appDir`, `linkingFile`, `screensResolved` are examples.
+
+### Identity is not reachability
+
+`urlPath` used to be both the label and the way in. That only holds for
+file-based routing. A react-navigation screen registered on a navigator but
+missing from the linking config has no URL at all, and a Flutter or SwiftUI
+screen may never have one.
+
+So a route carries all three separately:
+
+- **`id`** — identity, stable across runs, what edges point at.
+- **`title`** — what the map calls it. Always present.
+- **`urlPath` + `reach`** — whether it can be deep-linked, and how.
+
+`reach: "navigation-only"` is the load-bearing one. It makes
+`deepLinkFor()` return null, keeps the capture stage from visiting the app root
+and filing the home screen under the route's name, seeds
+`capture.needsNavigation` in the bundle, and puts the screen on the agent's
+work queue to be reached by tapping.
+
+## Writing a provider
+
+Two exported functions and a `meta`:
+
+```js
+export const meta = { id: 'flutter', title: 'Flutter', reach: 'mixed' }
+
+// Cheap, read-only, must not throw.
+export function detect(ctx) {
+  if (!ctx.exists('pubspec.yaml')) return { score: 0, evidence: ['no pubspec.yaml'] }
+  return { score: 0.9, evidence: ['pubspec.yaml with go_router'] }
+}
+
+export function parse(ctx) {
+  return { routes: [...], edges: [...], layouts: [...] }
+}
+```
+
+`ctx` is the shared toolkit, bound to one project root:
+
+| | |
+|---|---|
+| `projectRoot`, `rel(abs)`, `exists(relPath)` | paths |
+| `walk(dir, { skip })` | recursive file list, skipping `node_modules` and friends by default |
+| `readFileOrNull(abs)` | |
+| `resolveImport(spec, fromFile)` | one import specifier → absolute path, alias-aware |
+| `firstPartyImports(src, fromRel)` | every first-party import of a file, as repo-relative paths |
+| `pathAliases()` | parsed `tsconfig.json` `compilerOptions.paths` (JSONC-tolerant) |
+| `appConfig()` | `{ name, scheme, slug }` from `app.json` or `app.config.*` |
+| `deps()`, `packageJson()` | |
+| `routeMatcher(urlPath)` | pattern → RegExp, understands `[param]` and `:param` |
+
+Register it in `registry.mjs`, add a fixture under `fixtures/`, and add a line
+to `fixtures/run-tests.mjs`.
+
+### Following links
+
+Both shipped providers scan a screen's own source **plus one import hop**, and
+skip any file imported by more than 8 routes. Links live in list items and
+cards, not in the screen module — but a header or tab bar imported by every
+screen would otherwise attribute its links to all of them and turn the graph
+into a hairball. Reuse that rule; `firstPartyImports` is what it is built on.
+
+## Custom providers
+
+The escape hatch, and the way a new framework earns a module here: prototype it
+as a command, upstream it once the shape has survived a real app.
+
+```jsonc
+{ "routes": { "provider": "custom", "command": "node tools/my-parser.mjs" } }
+```
+
+The command runs with the project root as CWD and `SCREENMAP_PROJECT_ROOT` set,
+and prints the fragment above as JSON on stdout. Only `id` and `slug` are
+required per route. stderr passes through for debugging.
+
+## Testing
+
+```bash
+node fixtures/run-tests.mjs            # check every fixture against its snapshot
+node fixtures/run-tests.mjs --update   # accept an intended change
+```
+
+Each fixture pins both the provider detection picks and the entire graph, so a
+change that silently re-routes a project to a different provider, or drops a
+route, fails here rather than in someone's capture run.

--- a/docs/scrmap-format.md
+++ b/docs/scrmap-format.md
@@ -38,7 +38,9 @@ myapp-2026-08-08.scrmap        (zip)
     "scheme": "bluesky",          // deep-link scheme, null if unknown
     "platform": "ios-simulator",
     "device": "iPhone 17 Pro",    // device captures were taken on
-    "mode": "react-navigation"    // or "expo-router" — how routes were discovered
+    "mode": "react-navigation"    // the route provider that discovered the screens:
+                                  //   expo-router | react-navigation | custom | …
+                                  //   (see docs/route-providers.md)
   },
   "generatedAt": "2026-08-06T14:00:00.000Z"
 }
@@ -50,7 +52,11 @@ myapp-2026-08-08.scrmap        (zip)
 {
   "nodes": [{
     "id": "Profile",                    // unique; route id from the producer
-    "urlPath": "/profile/:name",        // deep-link path pattern
+    "title": "Profile",                 // display label — ALWAYS present; use this to
+                                        //   label a node, not urlPath
+    "urlPath": "/profile/:name",        // deep-link path pattern; NULL when the screen
+                                        //   has no URL (normal in react-navigation)
+    "reach": "deep-link",               // "deep-link" | "navigation-only" | "unknown"
     "file": "src/view/screens/Profile.tsx",  // source file, if known
     "slug": "Profile",                  // screenshot base name
     "group": "profile",                 // visual grouping (navigator dir / path segment)
@@ -131,6 +137,15 @@ The **`.meta.json` sidecar** maps YAML step indexes (0-based, sparse) to cartogr
   deep links**; flows with `tap` / `type` / gesture steps are **interactive** —
   both replay via `argent flow run`, no agent needed.
 - **State variants** attach extra captures to a node; `screens/<slug>--<state>.png`.
+- **Labelling**: use `title`. It is always present, while `urlPath` is null for any
+  screen the producer could not give a URL — a react-navigation screen absent from the
+  linking config, for instance. Bundles packed before `title` existed have neither
+  field set on some nodes; fall back `title ?? urlPath ?? id`.
+- **reach** is the producer's static verdict on how a screen can be opened, decided
+  before any capture runs: `navigation-only` means there is no deep link at all, and
+  the capture stage must navigate to it rather than visiting a URL. It seeds
+  `capture.needsNavigation`, which remains the *observed* verdict and can also be set
+  by an agent that found a screen unreachable in practice.
 - **needsNavigation** nodes cannot be reached by bare deep link; their flow or note
   explains the in-app path.
 - Viewers must ignore unknown fields and reject `formatVersion` they don't support.

--- a/fixtures/demo-app/expected-graph.json
+++ b/fixtures/demo-app/expected-graph.json
@@ -1,6 +1,5 @@
 {
-  "generatedAt": "2026-08-03T15:55:29.685Z",
-  "projectRoot": "/Users/aleqsio/Projects/expo-map/fixtures/demo-app",
+  "appName": "Demo App",
   "scheme": "demoapp",
   "deepLinkTemplates": {
     "devBuild": "demoapp://<urlPath minus leading slash>",
@@ -25,6 +24,8 @@
       "id": "(tabs)/home",
       "file": "app/(tabs)/home.tsx",
       "urlPath": "/home",
+      "title": "/home",
+      "reach": "deep-link",
       "slug": "tabs_home",
       "params": [],
       "navigator": "Tabs",
@@ -40,6 +41,8 @@
       "id": "(tabs)/settings",
       "file": "app/(tabs)/settings.tsx",
       "urlPath": "/settings",
+      "title": "/settings",
+      "reach": "deep-link",
       "slug": "tabs_settings",
       "params": [],
       "navigator": "Tabs",
@@ -51,6 +54,8 @@
       "id": "+not-found",
       "file": "app/+not-found.tsx",
       "urlPath": "/+not-found",
+      "title": "/+not-found",
+      "reach": "deep-link",
       "slug": "+not-found",
       "params": [],
       "navigator": "Stack",
@@ -62,6 +67,8 @@
       "id": "about",
       "file": "app/about.tsx",
       "urlPath": "/about",
+      "title": "/about",
+      "reach": "deep-link",
       "slug": "about",
       "params": [],
       "navigator": "Stack",
@@ -73,6 +80,8 @@
       "id": "details/[id]",
       "file": "app/details/[id].tsx",
       "urlPath": "/details/[id]",
+      "title": "/details/[id]",
+      "reach": "deep-link",
       "slug": "details_id",
       "params": [
         "id"
@@ -96,6 +105,8 @@
       "id": "index",
       "file": "app/index.tsx",
       "urlPath": "/",
+      "title": "/",
+      "reach": "deep-link",
       "slug": "index",
       "params": [],
       "navigator": "Stack",
@@ -107,6 +118,8 @@
       "id": "modal",
       "file": "app/modal.tsx",
       "urlPath": "/modal",
+      "title": "/modal",
+      "reach": "deep-link",
       "slug": "modal",
       "params": [],
       "navigator": "Stack",
@@ -189,6 +202,8 @@
     "edges": 10,
     "unresolvedEdges": 0,
     "routesWithStateHints": 3,
-    "routesNeedingParams": 1
+    "routesNeedingParams": 1,
+    "navigationOnlyRoutes": 0,
+    "orphanRoutes": 0
   }
 }

--- a/fixtures/rn-demo-app/app.config.ts
+++ b/fixtures/rn-demo-app/app.config.ts
@@ -1,0 +1,7 @@
+export default {
+  expo: {
+    name: 'RN Demo',
+    slug: 'rn-demo-app',
+    scheme: 'rndemo',
+  },
+}

--- a/fixtures/rn-demo-app/expected-graph.json
+++ b/fixtures/rn-demo-app/expected-graph.json
@@ -1,0 +1,147 @@
+{
+  "appName": "RN Demo",
+  "scheme": "rndemo",
+  "deepLinkTemplates": {
+    "devBuild": "rndemo://<urlPath minus leading slash>",
+    "expoGo": "exp://127.0.0.1:8081/--<urlPath>"
+  },
+  "mode": "react-navigation",
+  "linkingFile": "src/navigation/linking.ts",
+  "screensResolved": 5,
+  "layouts": [
+    {
+      "file": "src/navigation/RootNavigator.tsx",
+      "dir": "Tabs",
+      "navigator": "Tabs"
+    },
+    {
+      "file": "src/navigation/RootNavigator.tsx",
+      "dir": "Stack",
+      "navigator": "Stack"
+    }
+  ],
+  "routes": [
+    {
+      "id": "Feed",
+      "file": "src/screens/FeedScreen.tsx",
+      "urlPath": "/feed",
+      "title": "Feed",
+      "reach": "deep-link",
+      "slug": "Feed",
+      "params": [],
+      "navigator": "Tabs",
+      "layoutDir": "Tabs",
+      "presentation": null,
+      "stateHints": []
+    },
+    {
+      "id": "Search",
+      "file": "src/screens/SearchScreen.tsx",
+      "urlPath": "/search",
+      "title": "Search",
+      "reach": "deep-link",
+      "slug": "Search",
+      "params": [],
+      "navigator": "Tabs",
+      "layoutDir": "Tabs",
+      "presentation": null,
+      "stateHints": []
+    },
+    {
+      "id": "Profile",
+      "file": "src/screens/ProfileScreen.tsx",
+      "urlPath": "/profile/:userId",
+      "title": "Profile",
+      "reach": "deep-link",
+      "slug": "Profile",
+      "params": [
+        "userId"
+      ],
+      "navigator": "Stack",
+      "layoutDir": "Stack",
+      "presentation": null,
+      "stateHints": [
+        {
+          "type": "bottom-sheet",
+          "lib": "gorhom-bottom-sheet",
+          "snapPoints": [
+            "25%",
+            "60%"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "Settings",
+      "file": "src/screens/SettingsScreen.tsx",
+      "urlPath": "/settings",
+      "title": "Settings",
+      "reach": "deep-link",
+      "slug": "Settings",
+      "params": [],
+      "navigator": "Stack",
+      "layoutDir": "Stack",
+      "presentation": "modal",
+      "stateHints": [
+        {
+          "type": "router-modal",
+          "presentation": "modal"
+        }
+      ]
+    },
+    {
+      "id": "Onboarding",
+      "file": "src/screens/OnboardingScreen.tsx",
+      "urlPath": null,
+      "title": "Onboarding",
+      "reach": "navigation-only",
+      "slug": "Onboarding",
+      "params": [],
+      "navigator": "Stack",
+      "layoutDir": "Stack",
+      "presentation": null,
+      "stateHints": [
+        {
+          "type": "rn-modal"
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "Feed",
+      "to": "Profile",
+      "raw": "navigate('Profile')",
+      "target": "/profile/:userId"
+    },
+    {
+      "from": "Search",
+      "to": "Settings",
+      "raw": "navigate('Settings')",
+      "target": "/settings"
+    },
+    {
+      "from": "Settings",
+      "to": "Onboarding",
+      "raw": "navigate('Onboarding')",
+      "target": "Onboarding"
+    },
+    {
+      "from": "Onboarding",
+      "to": "Feed",
+      "raw": "navigate('Feed')",
+      "target": "/feed"
+    }
+  ],
+  "summary": {
+    "mode": "react-navigation",
+    "routes": 5,
+    "layouts": 2,
+    "edges": 4,
+    "unresolvedEdges": 0,
+    "routesWithStateHints": 3,
+    "routesNeedingParams": 1,
+    "navigationOnlyRoutes": 1,
+    "orphanRoutes": 0
+  }
+}

--- a/fixtures/rn-demo-app/package.json
+++ b/fixtures/rn-demo-app/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "rn-demo-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "@react-navigation/native": "^7.0.0",
+    "@react-navigation/native-stack": "^7.0.0",
+    "@react-navigation/bottom-tabs": "^7.0.0",
+    "@gorhom/bottom-sheet": "^5.0.0",
+    "react-native": "0.81.0"
+  }
+}

--- a/fixtures/rn-demo-app/src/components/FeedItem.tsx
+++ b/fixtures/rn-demo-app/src/components/FeedItem.tsx
@@ -1,0 +1,13 @@
+import { Pressable, Text } from 'react-native'
+import { useNavigation } from '@react-navigation/native'
+
+// The link lives in the list item, not in the screen — the parser has to follow
+// one import hop to find it.
+export function FeedItem({ userId }: { userId: string }) {
+  const navigation = useNavigation()
+  return (
+    <Pressable onPress={() => navigation.navigate('Profile', { userId })}>
+      <Text>Open profile</Text>
+    </Pressable>
+  )
+}

--- a/fixtures/rn-demo-app/src/navigation/RootNavigator.tsx
+++ b/fixtures/rn-demo-app/src/navigation/RootNavigator.tsx
@@ -1,0 +1,35 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
+import FeedScreen from '@/screens/FeedScreen'
+import SearchScreen from '@/screens/SearchScreen'
+import ProfileScreen from '@/screens/ProfileScreen'
+import SettingsScreen from '@/screens/SettingsScreen'
+import OnboardingScreen from '@/screens/OnboardingScreen'
+import { PROFILE_SCREEN, SCREENS } from './routeNames'
+
+const Stack = createNativeStackNavigator()
+const Tab = createBottomTabNavigator()
+
+function MainTabs() {
+  return (
+    <Tab.Navigator>
+      <Tab.Screen name="Feed" component={FeedScreen} />
+      <Tab.Screen name={SCREENS.SEARCH} component={SearchScreen} />
+    </Tab.Navigator>
+  )
+}
+
+export function RootNavigator() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen name="Tabs" component={MainTabs} options={{ headerShown: false }} />
+      <Stack.Screen name={PROFILE_SCREEN} component={ProfileScreen} />
+      <Stack.Screen
+        name="Settings"
+        component={SettingsScreen}
+        options={({ route }) => ({ title: route.name, presentation: 'modal' })}
+      />
+      <Stack.Screen name="Onboarding" component={OnboardingScreen} />
+    </Stack.Navigator>
+  )
+}

--- a/fixtures/rn-demo-app/src/navigation/linking.ts
+++ b/fixtures/rn-demo-app/src/navigation/linking.ts
@@ -1,0 +1,19 @@
+import { PROFILE_SCREEN } from './routeNames'
+
+// Deliberately partial: Onboarding and the Tabs container have no URL, which is
+// the normal state of a react-navigation linking config.
+export const linking = {
+  prefixes: ['rndemo://'],
+  config: {
+    screens: {
+      Tabs: {
+        screens: {
+          Feed: 'feed',
+          Search: 'search',
+        },
+      },
+      Profile: 'profile/:userId',
+      Settings: 'settings',
+    },
+  },
+}

--- a/fixtures/rn-demo-app/src/navigation/routeNames.ts
+++ b/fixtures/rn-demo-app/src/navigation/routeNames.ts
@@ -1,0 +1,2 @@
+export const PROFILE_SCREEN = 'Profile'
+export const SCREENS = { SEARCH: 'Search', FEED: 'Feed' }

--- a/fixtures/rn-demo-app/src/screens/FeedScreen.tsx
+++ b/fixtures/rn-demo-app/src/screens/FeedScreen.tsx
@@ -1,0 +1,10 @@
+import { View } from 'react-native'
+import { FeedItem } from '@/components/FeedItem'
+
+export default function FeedScreen() {
+  return (
+    <View>
+      <FeedItem userId="42" />
+    </View>
+  )
+}

--- a/fixtures/rn-demo-app/src/screens/OnboardingScreen.tsx
+++ b/fixtures/rn-demo-app/src/screens/OnboardingScreen.tsx
@@ -1,0 +1,12 @@
+import { Button, Modal, View } from 'react-native'
+import { useNavigation } from '@react-navigation/native'
+
+export default function OnboardingScreen() {
+  const navigation = useNavigation()
+  return (
+    <View>
+      <Modal visible={false} />
+      <Button title="Done" onPress={() => navigation.navigate('Tabs', { screen: 'Feed' })} />
+    </View>
+  )
+}

--- a/fixtures/rn-demo-app/src/screens/ProfileScreen.tsx
+++ b/fixtures/rn-demo-app/src/screens/ProfileScreen.tsx
@@ -1,0 +1,13 @@
+import { useRef } from 'react'
+import { Button, View } from 'react-native'
+import BottomSheet from '@gorhom/bottom-sheet'
+
+export default function ProfileScreen() {
+  const sheet = useRef<BottomSheet>(null)
+  return (
+    <View>
+      <Button title="Options" onPress={() => sheet.current?.expand()} />
+      <BottomSheet ref={sheet} index={-1} snapPoints={['25%', '60%']} />
+    </View>
+  )
+}

--- a/fixtures/rn-demo-app/src/screens/SearchScreen.tsx
+++ b/fixtures/rn-demo-app/src/screens/SearchScreen.tsx
@@ -1,0 +1,11 @@
+import { Button, View } from 'react-native'
+import { useNavigation } from '@react-navigation/native'
+
+export default function SearchScreen() {
+  const navigation = useNavigation()
+  return (
+    <View>
+      <Button title="Settings" onPress={() => navigation.navigate('Settings')} />
+    </View>
+  )
+}

--- a/fixtures/rn-demo-app/src/screens/SettingsScreen.tsx
+++ b/fixtures/rn-demo-app/src/screens/SettingsScreen.tsx
@@ -1,0 +1,11 @@
+import { Button, View } from 'react-native'
+import { useNavigation } from '@react-navigation/native'
+
+export default function SettingsScreen() {
+  const navigation = useNavigation()
+  return (
+    <View>
+      <Button title="Replay intro" onPress={() => navigation.navigate('Onboarding')} />
+    </View>
+  )
+}

--- a/fixtures/rn-demo-app/tsconfig.json
+++ b/fixtures/rn-demo-app/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  // JSONC on purpose: the alias stripper has to survive this
+  "compilerOptions": {
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/fixtures/run-tests.mjs
+++ b/fixtures/run-tests.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// Snapshot tests for the route providers.
+//
+//   node fixtures/run-tests.mjs           # check every fixture against its snapshot
+//   node fixtures/run-tests.mjs --update  # rewrite the snapshots after an intended change
+//
+// Each fixture pins both the provider that detection picks and the whole graph,
+// so a change that silently re-routes a project to a different provider — or
+// quietly drops a route — fails here rather than in someone's capture run.
+
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const PARSER = path.join(HERE, '..', 'plugins', 'screenmap', 'skills', 'screenmap', 'scripts', 'parse-routes.mjs')
+const UPDATE = process.argv.includes('--update')
+
+const FIXTURES = [
+  { dir: 'demo-app', provider: 'expo-router' },
+  { dir: 'rn-demo-app', provider: 'react-navigation' },
+]
+
+// generatedAt and projectRoot are machine- and clock-specific.
+function stable(graph) {
+  const { generatedAt, projectRoot, ...rest } = graph
+  return rest
+}
+
+let failed = 0
+for (const { dir, provider } of FIXTURES) {
+  const root = path.join(HERE, dir)
+  const out = path.join(root, '.screenmap', 'out', 'graph.json')
+  let stderr = ''
+  try {
+    execFileSync('node', [PARSER, root, '--out', out], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+  } catch (e) {
+    console.error(`FAIL ${dir}: parser exited ${e.status}\n${e.stderr ?? ''}`)
+    failed++
+    continue
+  }
+  const graph = stable(JSON.parse(fs.readFileSync(out, 'utf8')))
+  fs.rmSync(path.join(root, '.screenmap'), { recursive: true, force: true })
+
+  if (graph.mode !== provider) {
+    console.error(`FAIL ${dir}: expected provider "${provider}", detection chose "${graph.mode}"`)
+    failed++
+    continue
+  }
+
+  const snapPath = path.join(HERE, dir, 'expected-graph.json')
+  const actual = JSON.stringify(graph, null, 2) + '\n'
+  if (UPDATE || !fs.existsSync(snapPath)) {
+    fs.writeFileSync(snapPath, actual)
+    console.log(`${UPDATE ? 'updated' : 'created'} ${dir}/expected-graph.json`)
+    continue
+  }
+  if (fs.readFileSync(snapPath, 'utf8') !== actual) {
+    console.error(`FAIL ${dir}: graph differs from expected-graph.json (re-run with --update if intended)`)
+    const a = fs.readFileSync(snapPath, 'utf8').split('\n')
+    const b = actual.split('\n')
+    for (let i = 0; i < Math.max(a.length, b.length); i++) {
+      if (a[i] !== b[i]) {
+        console.error(`  line ${i + 1}:\n    expected: ${a[i] ?? '<eof>'}\n    actual:   ${b[i] ?? '<eof>'}`)
+        break
+      }
+    }
+    failed++
+    continue
+  }
+  console.log(`ok   ${dir} — ${provider}, ${graph.routes.length} routes, ${graph.edges.length} edges`)
+}
+
+if (failed) {
+  console.error(`\n${failed} fixture(s) failed`)
+  process.exit(1)
+}
+console.log(`\nall ${FIXTURES.length} fixtures passed`)

--- a/plugins/screenmap/skills/screenmap/SKILL.md
+++ b/plugins/screenmap/skills/screenmap/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: screenmap
-description: Generate a visual navigation map of an Expo app. Statically parses expo-router routes and links for full coverage, then deep-links through every screen in the iOS simulator capturing screenshots — including runtime states like bottom sheet snap points and modals — and renders a self-contained HTML map. Also diffs two revisions into a PR preview (.diff.scrmap) showing which screens/edges were added, removed, or changed. Use when the user asks to map an Expo/React Native app's navigation, screens, or routes, wants a visual sitemap of their app, or wants to preview/review what a PR changes on-screen.
+description: Generate a visual navigation map of an Expo / React Native app. Statically parses routes and links (expo-router, react-navigation, or your own parser) for full coverage, then deep-links through every screen in the iOS simulator capturing screenshots — including runtime states like bottom sheet snap points and modals — and renders a self-contained HTML map. Also diffs two revisions into a PR preview (.diff.scrmap) showing which screens/edges were added, removed, or changed. Use when the user asks to map an Expo/React Native app's navigation, screens, or routes, wants a visual sitemap of their app, or wants to preview/review what a PR changes on-screen.
 ---
 
 # screenmap
 
-Produce a visual map of an Expo app's navigation: every expo-router route as a card with a screenshot, runtime state variants (bottom sheets at each snap point, modals), and navigation edges between screens.
+Produce a visual map of an Expo / React Native app's navigation: every route as a card with a screenshot, runtime state variants (bottom sheets at each snap point, modals), and navigation edges between screens.
 
 **Arguments:** optional path to the Expo project (default: current working directory). `--static` = skip the simulator phases and render a screenshot-less map. `pr <number>` or `diff <base>..<head>` = PR diff mode (see bottom).
 
@@ -48,7 +48,18 @@ Rules:
 node <this skill's dir>/scripts/parse-routes.mjs <project>
 ```
 
-Read the produced `<project>/.screenmap/out/graph.json` and report the summary to the user: route count, layouts (with navigator types), edges (flag unresolved ones), routes with state hints, routes needing params. If the parser finds no `app/` directory, this is not an expo-router project — say so and stop (bare react-navigation apps are not supported yet).
+The parser picks a **route provider** for the project — `expo-router`, `react-navigation`, or a `custom` command — and prints which one it chose and why. See `docs/route-providers.md` for the full contract.
+
+Read the produced `<project>/.screenmap/out/graph.json` and report the summary to the user: the provider (`mode`), route count, layouts (with navigator types), edges (flag unresolved ones), routes with state hints, routes needing params, and **routes with no deep link** (`navigationOnlyRoutes`).
+
+If the parser exits saying no provider recognised the project, or that two fit equally well, do not guess. Show the user the detection table it printed and ask which to use, then re-run with `--provider <id>`:
+
+```bash
+node <this skill's dir>/scripts/parse-routes.mjs <project> --detect          # scores only
+node <this skill's dir>/scripts/parse-routes.mjs <project> --provider react-navigation
+```
+
+A project whose screens are registered somewhere none of the providers read — a generated route table, a home-grown router — is not a dead end: write a small script that emits the graph fragment documented in `docs/route-providers.md` and point `.screenmap/config.json` at it with `{"routes":{"provider":"custom","command":"…"}}`.
 
 If `--static` was requested, jump to Phase 6.
 
@@ -72,7 +83,9 @@ If `--static` was requested, jump to Phase 6.
 
 ## Phase 4 — route sweep
 
-For each route in `graph.json` (substituting params from Phase 2; for `+not-found`, deep-link a garbage path like `/definitely-not-a-route`):
+**Routes with `"reach": "navigation-only"` have no deep link at all** — normal for react-navigation screens that are absent from the linking config. Do not deep-link them and do not visit the app root in their place: that captures the home screen under the wrong route's name, which is exactly the kind of silent bad capture Phase 4b exists to catch. Skip them in this phase, record `{"needsNavigation": true}` for them in `capture-status.json`, and reach them by tapping in Phase 5b — their nav flow is their capture.
+
+For each route with a URL (substituting params from Phase 2; for `+not-found`, deep-link a garbage path like `/definitely-not-a-route`):
 
 1. `open_url` (or `xcrun simctl openurl booted "<url>"`) with the route's deep link.
 2. Wait ~1–1.5s for the transition (MCP `wait`). Content screens that fetch over the network need 3–4s — a capture showing a spinner or loading skeleton means the wait was too short, not that the route is broken; the Phase 4b review catches these, and you re-capture with a longer wait.
@@ -118,7 +131,7 @@ Rules for this phase:
 
 ## Phase 5b — navigation flows (the tap path to every screen)
 
-Deep links are shorthands; the map's primary flow for each screen is the path a human takes. For every reachable route, record `flows/nav-<slug>.yaml` + sidecar (name `nav-<slug>`, title "Navigate to <urlPath>") that reaches it from app launch using real taps:
+Deep links are shorthands; the map's primary flow for each screen is the path a human takes. For every reachable route, record `flows/nav-<slug>.yaml` + sidecar (name `nav-<slug>`, title "Navigate to <title>") that reaches it from app launch using real taps:
 
 - Step 1 is always `open_url` to the app root (`scheme://`) — that's the app entry, not a shortcut. Everything after is taps/swipes.
 - **Every navigating tap records three things**: `coordinate` (device points), `target` (durable label), and `screen` (the route id it landed on). Verify the landing with an MCP screenshot BEFORE writing the step — a wrong `screen` poisons the graph.
@@ -264,5 +277,5 @@ changed-pixels render).
 ## Web fallback (no macOS simulator available, or user asks for web)
 
 - Start `npx expo start --web`, confirm `http://localhost:8081/_sitemap` lists the same routes as the parse (good cross-check).
-- Capture each route with `npx playwright screenshot --viewport-size=390,844 "http://localhost:8081<urlPath>" <project>/.screenmap/out/screens/<slug>.png` (needs `npx playwright install chromium` once; ask before installing).
+- Capture each route that has a `urlPath` with `npx playwright screenshot --viewport-size=390,844 "http://localhost:8081<urlPath>" <project>/.screenmap/out/screens/<slug>.png` (needs `npx playwright install chromium` once; ask before installing).
 - State pass on web: drive the browser pane manually (tap triggers), but note playwright captures are the ones saved to disk — for sheet states, prefer `npx playwright screenshot --full-page` after using its `--wait-for-timeout` or skip and note the limitation.

--- a/plugins/screenmap/skills/screenmap/scripts/pack-map.mjs
+++ b/plugins/screenmap/skills/screenmap/scripts/pack-map.mjs
@@ -46,7 +46,7 @@ const shotFiles = fs.existsSync(shotsDir)
   ? fs.readdirSync(shotsDir).filter((f) => /\.(png|jpe?g|webp)$/i.test(f))
   : []
 
-const appName = path.basename(graph.projectRoot ?? projectRoot)
+const appName = graph.appName ?? path.basename(graph.projectRoot ?? projectRoot)
 
 const nodes = graph.routes.map((r) => {
   const cs = captureStatus[r.id] ?? {}
@@ -57,7 +57,9 @@ const nodes = graph.routes.map((r) => {
     .sort((a, b) => a.name.localeCompare(b.name))
   return {
     id: r.id,
-    urlPath: r.urlPath,
+    urlPath: r.urlPath ?? null,
+    title: r.title ?? r.urlPath ?? r.id,
+    reach: r.reach ?? (r.urlPath ? 'deep-link' : 'navigation-only'),
     file: r.file ?? null,
     slug: r.slug,
     group: r.layoutDir ?? '',
@@ -68,7 +70,7 @@ const nodes = graph.routes.map((r) => {
     capture: {
       status: cs.status ?? (baseShot ? 'ok' : 'missing'),
       note: cs.note ?? null,
-      needsNavigation: cs.needsNavigation ?? false,
+      needsNavigation: cs.needsNavigation ?? r.reach === 'navigation-only',
       screenshot: baseShot ? 'screens/' + baseShot : null,
       states,
     },

--- a/plugins/screenmap/skills/screenmap/scripts/parse-routes.mjs
+++ b/plugins/screenmap/skills/screenmap/scripts/parse-routes.mjs
@@ -1,500 +1,111 @@
 #!/usr/bin/env node
-// Static route + link extractor. Two modes, one graph format:
-//   expo-router      — walks app/ implementing file-based routing conventions
-//   react-navigation — parses a route-map file (screen name → URL path, as in
-//                      Bluesky's src/routes.ts) plus Navigation.tsx screen bindings
+// Static route + link extractor.
 //
-// Usage: node parse-routes.mjs [projectRoot] [--out <path>] [--routes <file>]
+// This file is only the driver: it picks a route provider, runs it, and turns
+// the fragment it returns into graph.json. The framework-specific knowledge
+// lives in routes/providers/*.mjs — see docs/route-providers.md for the
+// contract and how to add one.
+//
+// Usage:
+//   node parse-routes.mjs [projectRoot] [--out <path>]
+//                         [--provider <id>] [--detect] [--list-providers]
+//
 // Output: JSON graph (default <projectRoot>/.screenmap/out/graph.json)
 
 import fs from 'node:fs'
 import path from 'node:path'
+import { createProjectCtx } from './routes/lib/project.mjs'
+import { normalize, validate } from './routes/lib/graph.mjs'
+import { PROVIDERS, select, detectAll, formatDetections } from './routes/registry.mjs'
 
 const args = process.argv.slice(2)
 let projectRoot = '.'
 let outPath = null
-let routesFileArg = null
+let providerId = null
+let detectOnly = false
 for (let i = 0; i < args.length; i++) {
-  if (args[i] === '--out') outPath = args[++i]
-  else if (args[i] === '--routes') routesFileArg = args[++i]
-  else projectRoot = args[i]
+  const a = args[i]
+  if (a === '--out') outPath = args[++i]
+  else if (a === '--provider') providerId = args[++i]
+  else if (a === '--detect') detectOnly = true
+  else if (a === '--list-providers') {
+    for (const p of PROVIDERS) console.log(`${p.meta.id.padEnd(18)} ${p.meta.title} (reach: ${p.meta.reach})`)
+    process.exit(0)
+  } else if (a === '--routes') {
+    // legacy flag from the single-file react-navigation mode; the provider now
+    // finds its own entry points
+    i++
+  } else projectRoot = a
 }
 projectRoot = path.resolve(projectRoot)
 outPath = outPath ?? path.join(projectRoot, '.screenmap', 'out', 'graph.json')
 
-// ---------- shared helpers ----------
+const ctx = createProjectCtx(projectRoot)
 
-function walk(dir) {
-  const out = []
-  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
-    const p = path.join(dir, e.name)
-    if (e.isDirectory()) out.push(...walk(p))
-    else out.push(p)
-  }
-  return out
+// .screenmap/config.json → routes: { provider, command }. Read directly rather
+// than through the CI config loader so the skill script stays dependency-free.
+let routesConfig = {}
+try {
+  routesConfig = JSON.parse(
+    fs.readFileSync(path.join(projectRoot, '.screenmap', 'config.json'), 'utf8')
+  ).routes ?? {}
+} catch {}
+
+if (detectOnly) {
+  console.log(formatDetections(detectAll(ctx)))
+  process.exit(0)
 }
 
-function escapeRe(s) {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+let provider, detections, reason
+try {
+  ({ provider, detections, reason } = select(ctx, { provider: providerId, config: routesConfig }))
+} catch (e) {
+  console.error(`error: ${e.message}`)
+  process.exit(1)
 }
 
-function rel(p) {
-  return path.relative(projectRoot, p).split(path.sep).join('/')
+ctx.opts = { ...routesConfig }
+ctx.config = routesConfig
+
+let fragment
+try {
+  fragment = provider.parse(ctx)
+} catch (e) {
+  console.error(`error: ${provider.meta.id}: ${e.message}`)
+  process.exit(1)
 }
 
-function readFileOrNull(p) {
-  try { return fs.readFileSync(p, 'utf8') } catch { return null }
-}
+const { graph, orphans } = normalize(fragment, ctx, { provider })
 
-// tsconfig.json is JSONC in the wild. The stripper must be string-aware: a
-// plain /*…*/ sweep eats a stock Expo `paths` block, because "@/*" opens a
-// comment and the "**/*.ts" in `include` closes it.
-function stripJsonc(src) {
-  let out = '', inStr = false, esc = false, line = false, block = false
-  for (let i = 0; i < src.length; i++) {
-    const c = src[i], n = src[i + 1]
-    if (line) { if (c === '\n') { line = false; out += c } continue }
-    if (block) { if (c === '*' && n === '/') { block = false; i++ } continue }
-    if (inStr) {
-      out += c
-      if (esc) esc = false
-      else if (c === '\\') esc = true
-      else if (c === '"') inStr = false
-      continue
-    }
-    if (c === '"') { inStr = true; out += c; continue }
-    if (c === '/' && n === '/') { line = true; i++; continue }
-    if (c === '/' && n === '*') { block = true; i++; continue }
-    out += c
-  }
-  return out.replace(/,(\s*[}\]])/g, '$1')
-}
-
-const IMPORT_EXT = ['.tsx', '.ts', '.jsx', '.js']
-let _aliases = null
-function pathAliases() {
-  if (_aliases) return _aliases
-  _aliases = []
-  const src = readFileOrNull(path.join(projectRoot, 'tsconfig.json'))
-  if (src) {
-    let cfg = null
-    try { cfg = JSON.parse(stripJsonc(src)) } catch { try { cfg = JSON.parse(src) } catch {} }
-    for (const [pat, targets] of Object.entries(cfg?.compilerOptions?.paths ?? {}))
-      _aliases.push({ prefix: pat.replace(/\*$/, ''), targets: targets.map((t) => t.replace(/\*$/, '').replace(/^\.\//, '')) })
-  }
-  return _aliases
-}
-
-function resolveToRel(candidate) {
-  for (const suffix of ['', ...IMPORT_EXT, ...IMPORT_EXT.map((e) => '/index' + e)]) {
-    const c = candidate + suffix
-    try { if (fs.statSync(path.join(projectRoot, c)).isFile()) return c } catch {}
-  }
-  return null
-}
-
-// repo-relative targets of a file's first-party imports; bare package imports
-// resolve to null and drop out
-function firstPartyImports(src, fromRel) {
-  const specs = [
-    ...src.matchAll(/(?:^|\n)\s*(?:import|export)\s[^'"]*?from\s*['"]([^'"]+)['"]/g),
-    ...src.matchAll(/(?:require|import)\(\s*['"]([^'"]+)['"]\s*\)/g),
-  ].map((m) => m[1])
-  const out = []
-  for (const spec of new Set(specs)) {
-    let hit = null
-    if (spec.startsWith('.')) {
-      hit = resolveToRel(path.posix.normalize(path.posix.join(path.posix.dirname(fromRel), spec)))
-    } else {
-      for (const a of pathAliases()) {
-        if (!spec.startsWith(a.prefix)) continue
-        for (const t of a.targets) {
-          hit = resolveToRel(path.posix.normalize(t + spec.slice(a.prefix.length)))
-          if (hit) break
-        }
-        if (hit) break
-      }
-    }
-    if (hit) out.push(hit)
-  }
-  return out
-}
-
-function readScheme() {
-  try {
-    const cfg = JSON.parse(fs.readFileSync(path.join(projectRoot, 'app.json'), 'utf8'))
-    const s = cfg.expo?.scheme ?? cfg.scheme
-    const v = (Array.isArray(s) ? s[0] : s) ?? null
-    if (v) return v
-  } catch {}
-  for (const f of ['app.config.js', 'app.config.ts']) {
-    try {
-      const src = fs.readFileSync(path.join(projectRoot, f), 'utf8')
-      const m = src.match(/\bscheme\s*:\s*["']([A-Za-z0-9._+-]+)["']/)
-      if (m) return m[1]
-    } catch {}
-  }
-  return null
-}
-
-// route pattern → regex; supports [param]/[...param] (expo) and :param (RN)
-function routeMatcher(urlPath) {
-  const re = urlPath
-    .split('/')
-    .map((seg) =>
-      seg.startsWith('[...') ? '.*'
-      : seg.startsWith('[') || seg.startsWith(':') ? '[^/]+'
-      : escapeRe(seg)
-    )
-    .join('/')
-  return new RegExp('^' + re + '/?$')
-}
-
-const SHEET_LIBS = [
-  ['@gorhom/bottom-sheet', 'gorhom-bottom-sheet'],
-  ['react-native-actions-sheet', 'actions-sheet'],
-  ['@lodev09/react-native-true-sheet', 'true-sheet'],
-  ['react-native-raw-bottom-sheet', 'raw-bottom-sheet'],
-]
-
-function extractHints(src) {
-  const hints = []
-  for (const [lib, label] of SHEET_LIBS) {
-    if (src.includes(lib)) {
-      const snap = src.match(/snapPoints\s*[:=][^[\n]*\[([^\]]+)\]/)
-      const snapPoints = snap
-        ? snap[1].split(',').map((s) => s.trim().replace(/["'`]/g, '')).filter(Boolean)
-        : null
-      hints.push({ type: 'bottom-sheet', lib: label, snapPoints })
-    }
-  }
-  // app-level dialog/sheet systems (e.g. Bluesky's Dialog is a native bottom sheet)
-  if (/useDialogControl|Dialog\.Outer/.test(src))
-    hints.push({ type: 'bottom-sheet', lib: 'app-dialog', snapPoints: null })
-  if (/<Modal[\s>]/.test(src)) hints.push({ type: 'rn-modal' })
-  return hints
-}
-
-// ---------- mode 1: expo-router ----------
-
-function parseExpoRouter(appDir) {
-  const EXTS = new Set(['.tsx', '.jsx', '.ts', '.js'])
-  const NON_ROUTE_BASES = new Set(['+html', '+native-intent', '+middleware'])
-
-  const entries = walk(appDir)
-    .filter((f) => EXTS.has(path.extname(f)))
-    .map((f) => {
-      const relApp = path.relative(appDir, f).split(path.sep).join('/')
-      const noExt = relApp.slice(0, -path.extname(relApp).length)
-      const base = path.posix.basename(noExt)
-      const dir = path.posix.dirname(noExt)
-      return { abs: f, noExt, base, dir: dir === '.' ? '' : dir }
-    })
-    .filter((e) => !e.base.endsWith('+api') && !NON_ROUTE_BASES.has(e.base))
-
-  const layoutEntries = entries.filter((e) => e.base === '_layout')
-  const screenEntries = entries.filter((e) => e.base !== '_layout')
-
-  const layoutsByDir = {}
-  for (const l of layoutEntries) {
-    const src = fs.readFileSync(l.abs, 'utf8')
-    const nav = src.match(/<\s*(NativeTabs|Tabs|Stack|Drawer|Slot)\b/)
-    layoutsByDir[l.dir] = { file: rel(l.abs), dir: l.dir, navigator: nav ? nav[1] : null, src }
-  }
-
-  function nearestLayout(dir) {
-    let d = dir
-    while (true) {
-      if (layoutsByDir[d]) return layoutsByDir[d]
-      if (d === '') return null
-      const parent = path.posix.dirname(d)
-      d = parent === '.' ? '' : parent
-    }
-  }
-
-  const presentations = []
-  for (const l of Object.values(layoutsByDir)) {
-    for (const tag of l.src.match(/<[\w.]*Screen\b[^>]*>/g) ?? []) {
-      const name = tag.match(/name\s*=\s*["']([^"']+)["']/)?.[1]
-      const presentation = tag.match(/presentation\s*:\s*["']([a-zA-Z]+)["']/)?.[1]
-      if (name && presentation)
-        presentations.push({ prefix: l.dir ? `${l.dir}/${name}` : name, presentation })
-    }
-  }
-
-  function toSlug(noExt) {
-    let s = noExt === 'index' ? 'index' : noExt.replace(/\/index$/, '')
-    s = s.replace(/[()[\]]/g, '').replace(/\.\.\./g, '').replace(/\//g, '_')
-    return s || 'index'
-  }
-
-  const routes = screenEntries.map((e) => {
-    const segments = e.noExt.split('/')
-    if (segments[segments.length - 1] === 'index') segments.pop()
-    const urlSegments = segments.filter((s) => !(s.startsWith('(') && s.endsWith(')')))
-    const urlPath = '/' + urlSegments.join('/')
-    const params = segments
-      .filter((s) => s.startsWith('[') && s.endsWith(']'))
-      .map((s) => s.slice(1, -1).replace(/^\.\.\./, ''))
-    const layout = nearestLayout(e.dir)
-    const presentation =
-      presentations.find((p) => e.noExt === p.prefix || e.noExt.startsWith(p.prefix + '/'))
-        ?.presentation ?? null
-    const src = fs.readFileSync(e.abs, 'utf8')
-    const stateHints = extractHints(src)
-    if (presentation && /modal/i.test(presentation))
-      stateHints.push({ type: 'router-modal', presentation })
-    return {
-      id: e.noExt, file: rel(e.abs), urlPath, slug: toSlug(e.noExt), params,
-      navigator: layout?.navigator ?? null, layoutDir: layout?.dir ?? null,
-      presentation, stateHints, _src: src,
-    }
-  })
-
-  const matchers = routes.map((r) => ({ route: r, re: routeMatcher(r.urlPath) }))
-  const HREF_RE = /href=\{?\s*["'`]([^"'`]+)["'`]/g
-  const PATHNAME_RE = /pathname\s*:\s*["'`]([^"'`]+)["'`]/g
-  const ROUTER_RE = /(?:router|navigation)\.(?:push|replace|navigate)\(\s*["'`]([^"'`]+)["'`]/g
-
-  // A route's own source is not where its links live in ordinary code: put the
-  // <Link> in a list-item component and the screen reads as unreachable. So the
-  // scan follows each route's first-party imports one hop.
-  //
-  // One hop, and not into shared chrome: a header or tab bar imported by most
-  // screens would otherwise attribute its links to every one of them and turn
-  // the graph into a hairball. Files imported by more than IMPORT_FANOUT_CAP
-  // routes are treated as chrome and skipped.
-  const IMPORT_FANOUT_CAP = 8
-  const importsOfRoute = new Map() // route.id → [repo-rel file]
-  const fanout = new Map() // repo-rel file → route count
-  for (const r of routes) {
-    const own = firstPartyImports(r._src, r.file)
-    importsOfRoute.set(r.id, own)
-    for (const f of new Set(own)) fanout.set(f, (fanout.get(f) ?? 0) + 1)
-  }
-
-  const edges = []
-  for (const r of routes) {
-    const raws = new Set()
-    const sources = [r._src]
-    for (const f of importsOfRoute.get(r.id) ?? []) {
-      if ((fanout.get(f) ?? 0) > IMPORT_FANOUT_CAP) continue
-      const s = readFileOrNull(path.join(projectRoot, f))
-      if (s) sources.push(s)
-    }
-    for (const src of sources)
-      for (const re of [HREF_RE, PATHNAME_RE, ROUTER_RE])
-        for (const m of src.matchAll(re)) raws.add(m[1])
-    for (const raw of raws) {
-      let t = raw.split(/[?#]/)[0]
-      if (/^(https?|mailto|tel):/.test(t)) continue
-      if (!t.startsWith('/')) {
-        t = path.posix.normalize(path.posix.join(path.posix.dirname(r.urlPath), t))
-        if (!t.startsWith('/')) t = '/' + t
-      }
-      if (t === '') t = '/'
-      // group segments are legal in hrefs but absent from urlPath; template-literal
-      // params (`/user/${id}`) become a concrete dummy for matching
-      const probe =
-        t.split('/')
-          .filter((s) => !(s.startsWith('(') && s.endsWith(')')))
-          .join('/')
-          .replace(/\$\{[^}]*\}/g, 'X') || '/'
-      const hit = matchers.find((m) => m.re.test(probe))
-      edges.push({ from: r.id, to: hit?.route.id ?? null, raw, target: t })
-    }
-  }
-
-  for (const r of routes) delete r._src
-  const layouts = Object.values(layoutsByDir).map(({ src, ...l }) => l)
-  return { mode: 'expo-router', appDir: rel(appDir), layouts, routes, edges }
-}
-
-// ---------- mode 2: react-navigation route map ----------
-
-function findRoutesFile() {
-  if (routesFileArg) return path.resolve(projectRoot, routesFileArg)
-  for (const c of ['src/routes.ts', 'src/routes.tsx', 'src/routes.js', 'routes.ts'])
-    if (fs.existsSync(path.join(projectRoot, c))) return path.join(projectRoot, c)
-  return null
-}
-
-function resolveImport(spec, fromFile) {
-  let base
-  if (spec.startsWith('#/')) base = path.join(projectRoot, 'src', spec.slice(2))
-  else if (spec.startsWith('.')) base = path.resolve(path.dirname(fromFile), spec)
-  else return null // package import
-  for (const suffix of ['', '.tsx', '.ts', '.jsx', '.js', '/index.tsx', '/index.ts']) {
-    const p = base + suffix
-    if (fs.existsSync(p) && fs.statSync(p).isFile()) return p
-  }
-  return null
-}
-
-function parseRouteMap(routesFile) {
-  const src = fs.readFileSync(routesFile, 'utf8')
-  const routes = []
-  const entryRe = /^\s*([A-Za-z0-9_]+):\s*(\[[^\]]*\]|["'`][^"'`\n]*["'`])/gm
-  for (const m of src.matchAll(entryRe)) {
-    const name = m[1]
-    const paths = [...m[2].matchAll(/["'`]([^"'`]+)["'`]/g)].map((x) => x[1])
-    if (!paths.length || !paths[0].startsWith('/')) continue
-    const urlPath = paths[0]
-    routes.push({
-      id: name,
-      file: rel(routesFile),
-      urlPath,
-      aliases: paths.slice(1),
-      slug: name,
-      params: urlPath.split('/').filter((s) => s.startsWith(':')).map((s) => s.slice(1)),
-      navigator: 'react-navigation',
-      layoutDir: null, // filled below from path grouping
-      presentation: null,
-      stateHints: [],
-    })
-  }
-
-  // group by first path segment when ≥2 routes share it; singletons go to root
-  const segCount = new Map()
-  for (const r of routes) {
-    const seg = r.urlPath.split('/')[1] ?? ''
-    segCount.set(seg, (segCount.get(seg) ?? 0) + 1)
-  }
-  for (const r of routes) {
-    const seg = r.urlPath.split('/')[1] ?? ''
-    r.layoutDir = segCount.get(seg) >= 2 && seg !== '' ? seg : ''
-  }
-  const layouts = [...new Set(routes.map((r) => r.layoutDir))].map((dir) => ({
-    file: rel(routesFile), dir, navigator: 'react-navigation',
-  }))
-
-  // screen name → component file, via Navigation.tsx bindings + its imports
-  const navFile = ['src/Navigation.tsx', 'src/Navigation.jsx', 'src/Navigation.ts', 'Navigation.tsx']
-    .map((c) => path.join(projectRoot, c))
-    .find((p) => fs.existsSync(p))
-  const componentFiles = {} // route id → abs file
-  if (navFile) {
-    const navSrc = fs.readFileSync(navFile, 'utf8')
-    const imports = {} // identifier → abs file
-    const importRe = /import\s+(?:([A-Za-z0-9_]+)\s*,?\s*)?(?:\{([^}]*)\})?\s*from\s*["']([^"']+)["']/g
-    for (const m of navSrc.matchAll(importRe)) {
-      const resolved = resolveImport(m[3], navFile)
-      if (!resolved) continue
-      if (m[1]) imports[m[1]] = resolved
-      for (const part of (m[2] ?? '').split(',')) {
-        const pm = part.trim().match(/^(?:type\s+)?([A-Za-z0-9_]+)(?:\s+as\s+([A-Za-z0-9_]+))?$/)
-        if (pm) imports[pm[2] ?? pm[1]] = resolved
-      }
-    }
-    const bindRe = /name="([A-Za-z0-9_]+)"[\s\S]{0,160}?(?:getComponent=\{\(\)\s*=>\s*([A-Za-z0-9_]+)\}|component=\{([A-Za-z0-9_]+)\})/g
-    for (const m of navSrc.matchAll(bindRe)) {
-      const file = imports[m[2] ?? m[3]]
-      if (file) componentFiles[m[1]] = file
-    }
-  }
-
-  // edges + state hints from each screen's component file (shallow: that file only)
-  const matchers = routes.map((r) => ({ route: r, re: routeMatcher(r.urlPath) }))
-  const routeById = Object.fromEntries(routes.map((r) => [r.id, r]))
-  const NAV_CALL_RE = /\b(?:navigate|push|replace)\(\s*["']([A-Za-z0-9_]+)["']/g
-  const LINK_RE = /(?:href|to)=\{?\s*["'`](\/[^"'`\s]*)["'`]/g
-  const edges = []
-  for (const r of routes) {
-    const file = componentFiles[r.id]
-    if (!file) continue
-    r.file = rel(file)
-    const src2 = fs.readFileSync(file, 'utf8')
-    r.stateHints = extractHints(src2)
-    const seen = new Set()
-    for (const m of src2.matchAll(NAV_CALL_RE)) {
-      const target = routeById[m[1]]
-      if (target && !seen.has(target.id)) {
-        seen.add(target.id)
-        edges.push({ from: r.id, to: target.id, raw: `navigate('${m[1]}')`, target: target.urlPath })
-      }
-    }
-    for (const m of src2.matchAll(LINK_RE)) {
-      const t = m[1].split(/[?#]/)[0].replace(/\$\{[^}]*\}/g, 'X') || '/'
-      const hit = matchers.find((x) => x.re.test(t))
-      if (hit && !seen.has(hit.route.id)) {
-        seen.add(hit.route.id)
-        edges.push({ from: r.id, to: hit.route.id, raw: m[1], target: t })
-      }
-    }
-  }
-
-  return {
-    mode: 'react-navigation',
-    routesFile: rel(routesFile),
-    navigationFile: navFile ? rel(navFile) : null,
-    componentsResolved: Object.keys(componentFiles).length,
-    layouts, routes, edges,
-  }
-}
-
-// ---------- main ----------
-
-const appDir = ['app', 'src/app']
-  .map((d) => path.join(projectRoot, d))
-  .find((d) => fs.existsSync(d))
-
-let parsed
-if (appDir) {
-  parsed = parseExpoRouter(appDir)
-} else {
-  const routesFile = findRoutesFile()
-  if (!routesFile) {
-    console.error(
-      `error: no app/ (expo-router) or src/routes.ts (react-navigation route map) found in ${projectRoot}`
-    )
-    process.exit(1)
-  }
-  parsed = parseRouteMap(routesFile)
-}
-
-const scheme = readScheme()
-// routes nothing links to. The root is every app's entry point, so it never
-// counts; neither does a tab or drawer child, which the navigator reaches by
-// structure rather than by a link. (Stack children do not get that pass — a
-// pushed screen needs something to push it.)
-const linkedTo = new Set(parsed.edges.map((e) => e.to).filter(Boolean))
-const structural = (r) =>
-  /tab|drawer/i.test(r.navigator ?? '') ||
-  /\([^)]*(?:tabs?|drawer)[^)]*\)/i.test(`${r.id}/${r.layoutDir ?? ''}`) ||
-  // expo-router specials (+not-found, +html, _sitemap) are reached by the
-  // router itself, never by a link
-  r.id.split('/').some((s) => s.startsWith('+') || s.startsWith('_'))
-const orphans = parsed.routes.filter(
-  (r) => r.urlPath !== '/' && !linkedTo.has(r.id) && !structural(r)
-)
-const graph = {
-  generatedAt: new Date().toISOString(),
-  projectRoot,
-  scheme,
-  deepLinkTemplates: {
-    devBuild: scheme ? `${scheme}://<urlPath minus leading slash>` : null,
-    expoGo: 'exp://127.0.0.1:8081/--<urlPath>',
-  },
-  ...parsed,
-  summary: {
-    mode: parsed.mode,
-    routes: parsed.routes.length,
-    layouts: parsed.layouts.length,
-    edges: parsed.edges.length,
-    unresolvedEdges: parsed.edges.filter((e) => e.to == null).length,
-    routesWithStateHints: parsed.routes.filter((r) => r.stateHints.length > 0).length,
-    routesNeedingParams: parsed.routes.filter((r) => r.params.length > 0).length,
-    orphanRoutes: orphans.length,
-  },
+const errs = validate(graph)
+if (errs.length) {
+  console.error(`error: ${provider.meta.id} produced an invalid graph:`)
+  for (const e of errs) console.error(`  - ${e}`)
+  process.exit(1)
 }
 
 fs.mkdirSync(path.dirname(outPath), { recursive: true })
 fs.writeFileSync(outPath, JSON.stringify(graph, null, 2))
 console.log(`wrote ${outPath}`)
 console.log(JSON.stringify(graph.summary))
+
+console.error(`provider: ${provider.meta.id} — ${reason}`)
+if (detections.length > 1 && !providerId)
+  console.error(formatDetections(detections.filter((d) => d.score > 0)))
+
+// Screens with no URL are expected in navigator-driven frameworks; say how many
+// so a map that is mostly tap-reachable does not look like a parse failure.
+const navOnly = graph.routes.filter((r) => !r.urlPath)
+if (navOnly.length)
+  console.error(
+    `note: ${navOnly.length} of ${graph.routes.length} route(s) have no deep link and must be reached by in-app navigation: ${navOnly.map((r) => r.id).join(', ')}`
+  )
+
 // A screen nothing links to is usually the parser missing the link, not the app
 // missing the route — `href={item.href}` and other computed targets cannot be
 // resolved statically. Say so, so a sparse map reads as a known limitation
 // rather than as the truth about the app.
 if (orphans.length)
-  console.error(`note: ${orphans.length} route(s) have no incoming link and may just be links this parser cannot read (e.g. computed href): ${orphans.map((r) => r.urlPath).join(', ')}`)
+  console.error(
+    `note: ${orphans.length} route(s) have no incoming link and may just be links this parser cannot read (e.g. computed href): ${orphans.map((r) => r.urlPath ?? r.id).join(', ')}`
+  )

--- a/plugins/screenmap/skills/screenmap/scripts/render-map.mjs
+++ b/plugins/screenmap/skills/screenmap/scripts/render-map.mjs
@@ -30,7 +30,11 @@ shotsDir = path.resolve(shotsDir ?? path.join(baseDir, 'screens'))
 outPath = path.resolve(outPath ?? path.join(baseDir, 'map.html'))
 
 const graph = JSON.parse(fs.readFileSync(graphPath, 'utf8'))
-const appName = path.basename(graph.projectRoot)
+const appName = graph.appName ?? path.basename(graph.projectRoot)
+
+// Every node needs a label, and not every framework gives every screen a URL:
+// react-navigation screens missing from the linking config have none at all.
+const label = (r) => r?.title ?? r?.urlPath ?? r?.id ?? '?'
 
 const shotFiles = fs.existsSync(shotsDir)
   ? fs.readdirSync(shotsDir).filter((f) => /\.(png|jpe?g|webp)$/i.test(f))
@@ -102,7 +106,7 @@ const routeById = Object.fromEntries(graph.routes.map((r) => [r.id, r]))
 
 // ---- mermaid overview ----
 const mmNodes = graph.routes
-  .map((r) => `  ${JSON.stringify(r.slug).replace(/"/g, '')}["${r.urlPath}"]`)
+  .map((r) => `  ${JSON.stringify(r.slug).replace(/"/g, '')}["${label(r)}"]`)
   .join('\n')
 const mmEdges = graph.edges
   .filter((e) => e.to && e.from !== e.to)
@@ -128,7 +132,7 @@ function routeCard(r) {
   const { base, states } = shotsFor(r.slug)
   const edges = edgesFrom.get(r.id) ?? []
   const shot = base
-    ? `<img class="shot" src="${imgSrc(base)}" alt="${esc(r.urlPath)}" loading="lazy">`
+    ? `<img class="shot" src="${imgSrc(base)}" alt="${esc(label(r))}" loading="lazy">`
     : `<div class="shot placeholder">no screenshot</div>`
   const stateRow = states.length
     ? `<div class="states">${states
@@ -142,7 +146,7 @@ function routeCard(r) {
     ? `<div class="edges">${edges
         .map((e) =>
           e.to
-            ? `<a class="chip" href="#route-${esc(routeById[e.to].slug)}" title="${esc(e.raw)}">→ ${esc(routeById[e.to].urlPath)}</a>`
+            ? `<a class="chip" href="#route-${esc(routeById[e.to].slug)}" title="${esc(e.raw)}">→ ${esc(label(routeById[e.to]))}</a>`
             : `<span class="chip unresolved" title="${esc(e.raw)}">→ ? ${esc(e.target)}</span>`
         )
         .join('')}</div>`
@@ -162,7 +166,7 @@ function routeCard(r) {
   return `
   <div class="card" id="route-${esc(r.slug)}">
     <div class="card-head">
-      <span class="url">${esc(r.urlPath)}</span>${badges}
+      <span class="url">${esc(label(r))}</span>${badges}
     </div>
     <div class="file">${esc(r.file)}</div>
     ${statusNote}
@@ -209,7 +213,7 @@ function flowsSection() {
   const cards = flows
     .map((f) => {
       const routeRef = f.route && routeById[f.route]
-        ? `<a class="chip" href="#route-${esc(routeById[f.route].slug)}">${esc(routeById[f.route].urlPath)}</a>`
+        ? `<a class="chip" href="#route-${esc(routeById[f.route].slug)}">${esc(label(routeById[f.route]))}</a>`
         : ''
       return `
   <div class="card flow" id="flow-${esc(f.name ?? f._file)}">
@@ -291,11 +295,11 @@ const html = `<!doctype html>
   <div class="summary">${s.routes ?? graph.routes.length} routes · ${s.layouts ?? '?'} layouts · ${s.edges ?? graph.edges.length} links${
     s.unresolvedEdges ? ` (${s.unresolvedEdges} unresolved)` : ''
   } · generated ${esc(graph.generatedAt ?? '')}</div>
-  ${missing.length ? `<div class="warnbox">⚠ ${missing.length} route(s) without a screenshot: ${missing.map((r) => esc(r.urlPath)).join(', ')}</div>` : ''}
+  ${missing.length ? `<div class="warnbox">⚠ ${missing.length} route(s) without a screenshot: ${missing.map((r) => esc(label(r))).join(', ')}</div>` : ''}
   ${(() => {
-    const nn = graph.routes.filter((r) => captureStatus[r.id]?.needsNavigation)
+    const nn = graph.routes.filter((r) => captureStatus[r.id]?.needsNavigation || r.reach === 'navigation-only')
     return nn.length
-      ? `<div class="warnbox">⚠ ${nn.length} route(s) not reachable by bare deep link (need in-app navigation or real data): ${nn.map((r) => `<a href="#route-${esc(r.slug)}">${esc(r.urlPath)}</a>`).join(', ')}</div>`
+      ? `<div class="warnbox">⚠ ${nn.length} route(s) not reachable by bare deep link (need in-app navigation or real data): ${nn.map((r) => `<a href="#route-${esc(r.slug)}">${esc(label(r))}</a>`).join(', ')}</div>`
       : ''
   })()}
   <details>

--- a/plugins/screenmap/skills/screenmap/scripts/routes/lib/graph.mjs
+++ b/plugins/screenmap/skills/screenmap/scripts/routes/lib/graph.mjs
@@ -1,0 +1,115 @@
+// Graph assembly: turns a provider's fragment into the graph.json contract.
+//
+// Providers return only what is specific to their framework — routes, edges,
+// layouts. Everything common (defaults, orphan detection, the summary block,
+// validation) happens here, so every provider gets identical treatment and a
+// new one cannot quietly emit a graph the rest of the pipeline mishandles.
+
+export function normalize(fragment, ctx, { provider }) {
+  const routes = fragment.routes.map((r) => ({
+    id: r.id,
+    file: r.file ?? null,
+    urlPath: r.urlPath ?? null,
+    // Identity and reachability are separate concerns. A screen registered on a
+    // navigator but absent from the linking config has no URL at all, which is
+    // ordinary in react-navigation and impossible in expo-router — so `title`
+    // is what every consumer labels a node with, and `reach` is what the
+    // capture stage branches on.
+    title: r.title ?? r.urlPath ?? r.id,
+    reach: r.reach ?? (r.urlPath ? 'deep-link' : 'navigation-only'),
+    slug: r.slug,
+    params: r.params ?? [],
+    navigator: r.navigator ?? null,
+    layoutDir: r.layoutDir ?? null,
+    presentation: r.presentation ?? null,
+    stateHints: r.stateHints ?? [],
+    ...(r.aliases ? { aliases: r.aliases } : {}),
+  }))
+
+  const edges = fragment.edges ?? []
+  const layouts = fragment.layouts ?? []
+  const { name: appName, scheme } = ctx.appConfig()
+
+  const graph = {
+    generatedAt: new Date().toISOString(),
+    projectRoot: ctx.projectRoot,
+    // The app's own name, not the directory it happens to sit in — checkouts
+    // and git worktrees are routinely named after a branch or a ticket.
+    appName,
+    scheme,
+    deepLinkTemplates: {
+      devBuild: scheme ? `${scheme}://<urlPath minus leading slash>` : null,
+      expoGo: 'exp://127.0.0.1:8081/--<urlPath>',
+    },
+    mode: provider.meta.id,
+    ...providerExtras(fragment),
+    layouts,
+    routes,
+    edges,
+  }
+
+  const orphans = findOrphans(routes, edges)
+  graph.summary = {
+    mode: provider.meta.id,
+    routes: routes.length,
+    layouts: layouts.length,
+    edges: edges.length,
+    unresolvedEdges: edges.filter((e) => e.to == null).length,
+    routesWithStateHints: routes.filter((r) => r.stateHints.length > 0).length,
+    routesNeedingParams: routes.filter((r) => r.params.length > 0).length,
+    navigationOnlyRoutes: routes.filter((r) => r.reach === 'navigation-only').length,
+    orphanRoutes: orphans.length,
+  }
+  return { graph, orphans }
+}
+
+// Provider-specific top-level keys (appDir, routesFile, navigationFile, …) ride
+// along untouched; they are diagnostics, not contract.
+function providerExtras(fragment) {
+  const { routes, edges, layouts, ...rest } = fragment
+  return rest
+}
+
+// Routes nothing links to. The root is every app's entry point, so it never
+// counts; neither does a tab or drawer child, which the navigator reaches by
+// structure rather than by a link. (Stack children do not get that pass — a
+// pushed screen needs something to push it.)
+export function findOrphans(routes, edges) {
+  const linkedTo = new Set(edges.map((e) => e.to).filter(Boolean))
+  const structural = (r) =>
+    /tab|drawer/i.test(r.navigator ?? '') ||
+    /\([^)]*(?:tabs?|drawer)[^)]*\)/i.test(`${r.id}/${r.layoutDir ?? ''}`) ||
+    // expo-router specials (+not-found, +html, _sitemap) are reached by the
+    // router itself, never by a link
+    r.id.split('/').some((s) => s.startsWith('+') || s.startsWith('_'))
+  return routes.filter((r) => r.urlPath !== '/' && !linkedTo.has(r.id) && !structural(r))
+}
+
+// Contract violations a provider can plausibly ship: duplicate ids silently
+// collapse nodes in the viewer, duplicate slugs make two routes fight over one
+// screenshot file. Both are worth failing on rather than debugging downstream.
+export function validate(graph) {
+  const errs = []
+  const seenId = new Set()
+  const seenSlug = new Set()
+  for (const r of graph.routes) {
+    if (!r.id) errs.push(`route with no id: ${JSON.stringify(r)}`)
+    if (!r.slug) errs.push(`route "${r.id}" has no slug`)
+    if (seenId.has(r.id)) errs.push(`duplicate route id "${r.id}"`)
+    if (r.slug && seenSlug.has(r.slug)) errs.push(`duplicate slug "${r.slug}" (screenshots would collide)`)
+    // Screenshots are <slug>.png and state variants are <slug>--<state>.png,
+    // so a slug may not contain a path separator or the state separator.
+    if (r.slug && !/^[A-Za-z0-9_.+-]+$/.test(r.slug))
+      errs.push(`slug "${r.slug}" on route "${r.id}" is not filename-safe`)
+    if (r.slug && r.slug.includes('--'))
+      errs.push(`slug "${r.slug}" on route "${r.id}" contains "--", which names state variants`)
+    seenId.add(r.id)
+    if (r.slug) seenSlug.add(r.slug)
+  }
+  const ids = new Set(graph.routes.map((r) => r.id))
+  for (const e of graph.edges) {
+    if (!ids.has(e.from)) errs.push(`edge from unknown route "${e.from}"`)
+    if (e.to != null && !ids.has(e.to)) errs.push(`edge to unknown route "${e.to}"`)
+  }
+  return errs
+}

--- a/plugins/screenmap/skills/screenmap/scripts/routes/lib/hints.mjs
+++ b/plugins/screenmap/skills/screenmap/scripts/routes/lib/hints.mjs
@@ -1,0 +1,29 @@
+// Runtime-state hints: the things a screenshot of a route's initial render
+// cannot show. Static analysis can only say "this screen probably has a bottom
+// sheet" — Phase 5 of the skill is what actually opens it.
+
+export const SHEET_LIBS = [
+  ['@expo/ui/community/bottom-sheet', 'expo-ui-bottom-sheet'],
+  ['@gorhom/bottom-sheet', 'gorhom-bottom-sheet'],
+  ['react-native-actions-sheet', 'actions-sheet'],
+  ['@lodev09/react-native-true-sheet', 'true-sheet'],
+  ['react-native-raw-bottom-sheet', 'raw-bottom-sheet'],
+]
+
+export function extractHints(src, { sheetLibs = SHEET_LIBS } = {}) {
+  const hints = []
+  for (const [lib, label] of sheetLibs) {
+    if (src.includes(lib)) {
+      const snap = src.match(/snapPoints\s*[:=][^[\n]*\[([^\]]+)\]/)
+      const snapPoints = snap
+        ? snap[1].split(',').map((s) => s.trim().replace(/["'`]/g, '')).filter(Boolean)
+        : null
+      hints.push({ type: 'bottom-sheet', lib: label, snapPoints })
+    }
+  }
+  // app-level dialog/sheet systems (e.g. Bluesky's Dialog is a native bottom sheet)
+  if (/useDialogControl|Dialog\.Outer/.test(src))
+    hints.push({ type: 'bottom-sheet', lib: 'app-dialog', snapPoints: null })
+  if (/<Modal[\s>]/.test(src)) hints.push({ type: 'rn-modal' })
+  return hints
+}

--- a/plugins/screenmap/skills/screenmap/scripts/routes/lib/project.mjs
+++ b/plugins/screenmap/skills/screenmap/scripts/routes/lib/project.mjs
@@ -1,0 +1,191 @@
+// Project-shaped helpers shared by every route provider: filesystem walking,
+// TypeScript path-alias resolution, import following, and app config reading.
+//
+// Everything is bound to a projectRoot through createProjectCtx() rather than
+// read from module state, so a driver can hold two roots at once (the PR diff
+// lane parses a base and a head checkout in one process).
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const IMPORT_EXT = ['.tsx', '.ts', '.jsx', '.js']
+const DEFAULT_SKIP = /(^|\/)(node_modules|\.git|\.expo|\.screenmap|ios|android|build|dist)(\/|$)/
+
+export function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+// route pattern → regex; supports [param]/[...param] (expo) and :param (RN)
+export function routeMatcher(urlPath) {
+  const re = urlPath
+    .split('/')
+    .map((seg) =>
+      seg.startsWith('[...') ? '.*'
+      : seg.startsWith('[') || seg.startsWith(':') ? '[^/]+'
+      : escapeRe(seg)
+    )
+    .join('/')
+  return new RegExp('^' + re + '/?$')
+}
+
+// tsconfig.json is JSONC in the wild. The stripper must be string-aware: a
+// plain /*…*/ sweep eats a stock Expo `paths` block, because "@/*" opens a
+// comment and the "**/*.ts" in `include` closes it.
+export function stripJsonc(src) {
+  let out = '', inStr = false, esc = false, line = false, block = false
+  for (let i = 0; i < src.length; i++) {
+    const c = src[i], n = src[i + 1]
+    if (line) { if (c === '\n') { line = false; out += c } continue }
+    if (block) { if (c === '*' && n === '/') { block = false; i++ } continue }
+    if (inStr) {
+      out += c
+      if (esc) esc = false
+      else if (c === '\\') esc = true
+      else if (c === '"') inStr = false
+      continue
+    }
+    if (c === '"') { inStr = true; out += c; continue }
+    if (c === '/' && n === '/') { line = true; i++; continue }
+    if (c === '/' && n === '*') { block = true; i++; continue }
+    out += c
+  }
+  return out.replace(/,(\s*[}\]])/g, '$1')
+}
+
+export function createProjectCtx(projectRoot) {
+  const rel = (p) => path.relative(projectRoot, p).split(path.sep).join('/')
+
+  const readFileOrNull = (p) => {
+    try { return fs.readFileSync(p, 'utf8') } catch { return null }
+  }
+
+  // Recursive file list. `skip` defaults to the directories no route ever lives
+  // in; a provider walking the whole source tree would otherwise spend its time
+  // in node_modules.
+  function walk(dir, { skip = DEFAULT_SKIP } = {}) {
+    const out = []
+    let entries
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }) } catch { return out }
+    for (const e of entries) {
+      const p = path.join(dir, e.name)
+      if (skip && skip.test(rel(p))) continue
+      if (e.isDirectory()) out.push(...walk(p, { skip }))
+      else out.push(p)
+    }
+    return out
+  }
+
+  let _aliases = null
+  function pathAliases() {
+    if (_aliases) return _aliases
+    _aliases = []
+    const src = readFileOrNull(path.join(projectRoot, 'tsconfig.json'))
+    if (src) {
+      let cfg = null
+      try { cfg = JSON.parse(stripJsonc(src)) } catch { try { cfg = JSON.parse(src) } catch {} }
+      for (const [pat, targets] of Object.entries(cfg?.compilerOptions?.paths ?? {}))
+        _aliases.push({
+          prefix: pat.replace(/\*$/, ''),
+          targets: targets.map((t) => t.replace(/\*$/, '').replace(/^\.\//, '')),
+        })
+    }
+    return _aliases
+  }
+
+  function resolveToRel(candidate) {
+    for (const suffix of ['', ...IMPORT_EXT, ...IMPORT_EXT.map((e) => '/index' + e)]) {
+      const c = candidate + suffix
+      try { if (fs.statSync(path.join(projectRoot, c)).isFile()) return c } catch {}
+    }
+    return null
+  }
+
+  // repo-relative targets of a file's first-party imports; bare package imports
+  // resolve to null and drop out
+  function firstPartyImports(src, fromRel) {
+    const specs = [
+      ...src.matchAll(/(?:^|\n)\s*(?:import|export)\s[^'"]*?from\s*['"]([^'"]+)['"]/g),
+      ...src.matchAll(/(?:require|import)\(\s*['"]([^'"]+)['"]\s*\)/g),
+    ].map((m) => m[1])
+    const out = []
+    for (const spec of new Set(specs)) {
+      let hit = null
+      if (spec.startsWith('.')) {
+        hit = resolveToRel(path.posix.normalize(path.posix.join(path.posix.dirname(fromRel), spec)))
+      } else {
+        for (const a of pathAliases()) {
+          if (!spec.startsWith(a.prefix)) continue
+          for (const t of a.targets) {
+            hit = resolveToRel(path.posix.normalize(t + spec.slice(a.prefix.length)))
+            if (hit) break
+          }
+          if (hit) break
+        }
+      }
+      if (hit) out.push(hit)
+    }
+    return out
+  }
+
+  // Absolute path for an import written from `fromFile`, covering the relative
+  // and alias forms plus the `#/` convention some RN apps use for `src/`.
+  function resolveImport(spec, fromFile) {
+    if (spec.startsWith('#/')) {
+      const hit = resolveToRel(path.posix.join('src', spec.slice(2)))
+      return hit ? path.join(projectRoot, hit) : null
+    }
+    const fromRel = rel(fromFile)
+    const [hit] = firstPartyImports(`import x from '${spec}'`, fromRel)
+    return hit ? path.join(projectRoot, hit) : null
+  }
+
+  // app.json first, then the dynamic configs. The dynamic path is a regex over
+  // source — app.config.ts can compute its values, and running it would mean
+  // executing project code inside the parser.
+  let _appConfig = null
+  function appConfig() {
+    if (_appConfig) return _appConfig
+    const pick = (v) => (Array.isArray(v) ? v[0] : v) ?? null
+    let name = null, scheme = null, slug = null
+    const json = readFileOrNull(path.join(projectRoot, 'app.json'))
+    if (json) {
+      try {
+        const cfg = JSON.parse(json)
+        const e = cfg.expo ?? cfg
+        name = e.name ?? null
+        scheme = pick(e.scheme)
+        slug = e.slug ?? null
+      } catch {}
+    }
+    if (!name || !scheme) {
+      for (const f of ['app.config.ts', 'app.config.js', 'app.config.mjs']) {
+        const src = readFileOrNull(path.join(projectRoot, f))
+        if (!src) continue
+        if (!name) name = src.match(/\bname\s*:\s*["'`]([^"'`]+)["'`]/)?.[1] ?? null
+        if (!scheme) scheme = src.match(/\bscheme\s*:\s*["'`]([A-Za-z0-9._+-]+)["'`]/)?.[1] ?? null
+        if (!slug) slug = src.match(/\bslug\s*:\s*["'`]([^"'`]+)["'`]/)?.[1] ?? null
+        if (name && scheme) break
+      }
+    }
+    _appConfig = { name: name ?? path.basename(projectRoot), scheme, slug }
+    return _appConfig
+  }
+
+  function packageJson() {
+    try { return JSON.parse(readFileOrNull(path.join(projectRoot, 'package.json')) ?? '{}') } catch { return {} }
+  }
+
+  // Every dependency name, whichever section it is declared in.
+  function deps() {
+    const pkg = packageJson()
+    return { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}), ...(pkg.peerDependencies ?? {}) }
+  }
+
+  const exists = (p) => fs.existsSync(path.join(projectRoot, p))
+
+  return {
+    projectRoot, rel, exists, walk, readFileOrNull, resolveToRel, resolveImport,
+    firstPartyImports, pathAliases, appConfig, packageJson, deps,
+    routeMatcher, escapeRe,
+  }
+}

--- a/plugins/screenmap/skills/screenmap/scripts/routes/providers/custom.mjs
+++ b/plugins/screenmap/skills/screenmap/scripts/routes/providers/custom.mjs
@@ -1,0 +1,71 @@
+// custom — delegate route discovery to a command the project owns.
+//
+// This is the escape hatch that keeps the skill's "write your own parser" story
+// first-class, and the way a new framework gets proven before it earns a
+// provider module in this directory: prototype it as a command, and upstream it
+// once the shape has survived contact with a real app.
+//
+//   .screenmap/config.json
+//   { "routes": { "provider": "custom", "command": "node tools/my-parser.mjs" } }
+//
+// The command runs with CWD set to the project root and SCREENMAP_PROJECT_ROOT
+// in the environment. It must print a JSON fragment on stdout:
+//
+//   { "routes": [ … ], "edges": [ … ], "layouts": [ … ] }
+//
+// Routes need at least `id` and `slug`; everything else the driver fills in.
+// Anything written to stderr is passed through for debugging.
+
+import { execSync } from 'node:child_process'
+
+export const meta = {
+  id: 'custom',
+  title: 'Custom command',
+  reach: 'unknown',
+}
+
+// Never auto-detected — opting in is the whole point.
+export function detect() {
+  return { score: 0, evidence: ['opt-in only: set routes.provider = "custom"'] }
+}
+
+export function parse(ctx) {
+  const command = ctx.opts?.command ?? ctx.config?.command
+  if (!command) {
+    throw new Error(
+      'routes.provider is "custom" but no routes.command is set in .screenmap/config.json'
+    )
+  }
+
+  let stdout
+  try {
+    stdout = execSync(command, {
+      cwd: ctx.projectRoot,
+      env: { ...process.env, SCREENMAP_PROJECT_ROOT: ctx.projectRoot },
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'inherit'],
+      maxBuffer: 64 * 1024 * 1024,
+    })
+  } catch (e) {
+    throw new Error(`routes.command failed (${command}): ${e.message}`)
+  }
+
+  let fragment
+  try {
+    fragment = JSON.parse(stdout)
+  } catch {
+    throw new Error(
+      `routes.command did not print JSON on stdout (${command}). ` +
+      `Expected { "routes": [...], "edges": [...] }, got: ${stdout.slice(0, 200)}`
+    )
+  }
+  if (!Array.isArray(fragment?.routes)) {
+    throw new Error(`routes.command output has no "routes" array (${command})`)
+  }
+  return {
+    command,
+    layouts: fragment.layouts ?? [],
+    routes: fragment.routes,
+    edges: fragment.edges ?? [],
+  }
+}

--- a/plugins/screenmap/skills/screenmap/scripts/routes/providers/expo-router.mjs
+++ b/plugins/screenmap/skills/screenmap/scripts/routes/providers/expo-router.mjs
@@ -1,0 +1,184 @@
+// expo-router — file-based routing under app/. The directory tree *is* the URL
+// space, so every route is deep-linkable and reachability needs no inference.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { extractHints } from '../lib/hints.mjs'
+
+export const meta = {
+  id: 'expo-router',
+  title: 'Expo Router',
+  reach: 'deep-link',
+}
+
+const APP_DIRS = ['app', 'src/app']
+
+function findAppDir(ctx) {
+  return APP_DIRS.map((d) => path.join(ctx.projectRoot, d)).find((d) => fs.existsSync(d)) ?? null
+}
+
+// An `app/` directory is not by itself expo-router — plenty of react-navigation
+// apps use app/ as a source root. The route tree is what distinguishes them:
+// expo-router needs a _layout, and the dependency seals it.
+export function detect(ctx) {
+  const evidence = []
+  let score = 0
+  const appDir = findAppDir(ctx)
+  if (!appDir) return { score: 0, evidence: ['no app/ or src/app/'] }
+
+  const files = ctx.walk(appDir, { skip: null })
+  const hasLayout = files.some((f) => /(^|\/)_layout\.[jt]sx?$/.test(ctx.rel(f)))
+  if (hasLayout) {
+    score += 0.6
+    evidence.push(`${ctx.rel(appDir)}/ contains a _layout route`)
+  } else {
+    evidence.push(`${ctx.rel(appDir)}/ exists but has no _layout`)
+  }
+
+  if (ctx.deps()['expo-router']) {
+    score += 0.35
+    evidence.push('expo-router in package.json')
+  }
+  // A bare app/ tree of .tsx files with no _layout and no dependency is more
+  // likely a source root than a router tree, so it stays below the threshold.
+  if (!hasLayout && !ctx.deps()['expo-router']) score = 0.1
+
+  return { score: Math.min(score, 1), evidence, appDir: ctx.rel(appDir) }
+}
+
+export function parse(ctx) {
+  const appDir = findAppDir(ctx)
+  if (!appDir) throw new Error('expo-router: no app/ or src/app/ directory')
+
+  const rel = ctx.rel
+  const EXTS = new Set(['.tsx', '.jsx', '.ts', '.js'])
+  const NON_ROUTE_BASES = new Set(['+html', '+native-intent', '+middleware'])
+
+  const entries = ctx.walk(appDir, { skip: null })
+    .filter((f) => EXTS.has(path.extname(f)))
+    .map((f) => {
+      const relApp = path.relative(appDir, f).split(path.sep).join('/')
+      const noExt = relApp.slice(0, -path.extname(relApp).length)
+      const base = path.posix.basename(noExt)
+      const dir = path.posix.dirname(noExt)
+      return { abs: f, noExt, base, dir: dir === '.' ? '' : dir }
+    })
+    .filter((e) => !e.base.endsWith('+api') && !NON_ROUTE_BASES.has(e.base))
+
+  const layoutEntries = entries.filter((e) => e.base === '_layout')
+  const screenEntries = entries.filter((e) => e.base !== '_layout')
+
+  const layoutsByDir = {}
+  for (const l of layoutEntries) {
+    const src = fs.readFileSync(l.abs, 'utf8')
+    const nav = src.match(/<\s*(NativeTabs|Tabs|Stack|Drawer|Slot)\b/)
+    layoutsByDir[l.dir] = { file: rel(l.abs), dir: l.dir, navigator: nav ? nav[1] : null, src }
+  }
+
+  function nearestLayout(dir) {
+    let d = dir
+    while (true) {
+      if (layoutsByDir[d]) return layoutsByDir[d]
+      if (d === '') return null
+      const parent = path.posix.dirname(d)
+      d = parent === '.' ? '' : parent
+    }
+  }
+
+  const presentations = []
+  for (const l of Object.values(layoutsByDir)) {
+    for (const tag of l.src.match(/<[\w.]*Screen\b[^>]*>/g) ?? []) {
+      const name = tag.match(/name\s*=\s*["']([^"']+)["']/)?.[1]
+      const presentation = tag.match(/presentation\s*:\s*["']([a-zA-Z]+)["']/)?.[1]
+      if (name && presentation)
+        presentations.push({ prefix: l.dir ? `${l.dir}/${name}` : name, presentation })
+    }
+  }
+
+  function toSlug(noExt) {
+    let s = noExt === 'index' ? 'index' : noExt.replace(/\/index$/, '')
+    s = s.replace(/[()[\]]/g, '').replace(/\.\.\./g, '').replace(/\//g, '_')
+    return s || 'index'
+  }
+
+  const routes = screenEntries.map((e) => {
+    const segments = e.noExt.split('/')
+    if (segments[segments.length - 1] === 'index') segments.pop()
+    const urlSegments = segments.filter((s) => !(s.startsWith('(') && s.endsWith(')')))
+    const urlPath = '/' + urlSegments.join('/')
+    const params = segments
+      .filter((s) => s.startsWith('[') && s.endsWith(']'))
+      .map((s) => s.slice(1, -1).replace(/^\.\.\./, ''))
+    const layout = nearestLayout(e.dir)
+    const presentation =
+      presentations.find((p) => e.noExt === p.prefix || e.noExt.startsWith(p.prefix + '/'))
+        ?.presentation ?? null
+    const src = fs.readFileSync(e.abs, 'utf8')
+    const stateHints = extractHints(src)
+    if (presentation && /modal/i.test(presentation))
+      stateHints.push({ type: 'router-modal', presentation })
+    return {
+      id: e.noExt, file: rel(e.abs), urlPath, slug: toSlug(e.noExt), params,
+      navigator: layout?.navigator ?? null, layoutDir: layout?.dir ?? null,
+      presentation, stateHints, _src: src,
+    }
+  })
+
+  const matchers = routes.map((r) => ({ route: r, re: ctx.routeMatcher(r.urlPath) }))
+  const HREF_RE = /href=\{?\s*["'`]([^"'`]+)["'`]/g
+  const PATHNAME_RE = /pathname\s*:\s*["'`]([^"'`]+)["'`]/g
+  const ROUTER_RE = /(?:router|navigation)\.(?:push|replace|navigate)\(\s*["'`]([^"'`]+)["'`]/g
+
+  // A route's own source is not where its links live in ordinary code: put the
+  // <Link> in a list-item component and the screen reads as unreachable. So the
+  // scan follows each route's first-party imports one hop.
+  //
+  // One hop, and not into shared chrome: a header or tab bar imported by most
+  // screens would otherwise attribute its links to every one of them and turn
+  // the graph into a hairball. Files imported by more than IMPORT_FANOUT_CAP
+  // routes are treated as chrome and skipped.
+  const IMPORT_FANOUT_CAP = 8
+  const importsOfRoute = new Map() // route.id → [repo-rel file]
+  const fanout = new Map() // repo-rel file → route count
+  for (const r of routes) {
+    const own = ctx.firstPartyImports(r._src, r.file)
+    importsOfRoute.set(r.id, own)
+    for (const f of new Set(own)) fanout.set(f, (fanout.get(f) ?? 0) + 1)
+  }
+
+  const edges = []
+  for (const r of routes) {
+    const raws = new Set()
+    const sources = [r._src]
+    for (const f of importsOfRoute.get(r.id) ?? []) {
+      if ((fanout.get(f) ?? 0) > IMPORT_FANOUT_CAP) continue
+      const s = ctx.readFileOrNull(path.join(ctx.projectRoot, f))
+      if (s) sources.push(s)
+    }
+    for (const src of sources)
+      for (const re of [HREF_RE, PATHNAME_RE, ROUTER_RE])
+        for (const m of src.matchAll(re)) raws.add(m[1])
+    for (const raw of raws) {
+      let t = raw.split(/[?#]/)[0]
+      if (/^(https?|mailto|tel):/.test(t)) continue
+      if (!t.startsWith('/')) {
+        t = path.posix.normalize(path.posix.join(path.posix.dirname(r.urlPath), t))
+        if (!t.startsWith('/')) t = '/' + t
+      }
+      if (t === '') t = '/'
+      // group segments are legal in hrefs but absent from urlPath; template-literal
+      // params (`/user/${id}`) become a concrete dummy for matching
+      const probe =
+        t.split('/')
+          .filter((s) => !(s.startsWith('(') && s.endsWith(')')))
+          .join('/')
+          .replace(/\$\{[^}]*\}/g, 'X') || '/'
+      const hit = matchers.find((m) => m.re.test(probe))
+      edges.push({ from: r.id, to: hit?.route.id ?? null, raw, target: t })
+    }
+  }
+
+  for (const r of routes) delete r._src
+  const layouts = Object.values(layoutsByDir).map(({ src, ...l }) => l)
+  return { appDir: rel(appDir), layouts, routes, edges }
+}

--- a/plugins/screenmap/skills/screenmap/scripts/routes/providers/react-navigation.mjs
+++ b/plugins/screenmap/skills/screenmap/scripts/routes/providers/react-navigation.mjs
@@ -1,0 +1,482 @@
+// react-navigation — screens are registered on navigators in code, not derived
+// from the filesystem, so discovery works the other way round from expo-router:
+// find every <X.Screen name=… component=…>, then overlay the linking config to
+// learn which of them have a URL.
+//
+// The overlay is the point. A react-navigation app's linking config is optional
+// and usually partial, so a screen having no URL is normal, not an error — it
+// is simply reachable by tapping rather than by deep link. Those screens still
+// belong on the map; they carry urlPath: null and the driver marks them
+// navigation-only so the capture stage navigates instead of deep-linking.
+
+import path from 'node:path'
+import { extractHints } from '../lib/hints.mjs'
+
+export const meta = {
+  id: 'react-navigation',
+  title: 'React Navigation',
+  reach: 'mixed',
+}
+
+const SRC_EXT = /\.(tsx?|jsx?)$/
+const SRC_DIRS = ['src', 'app', 'screens', 'navigation', '.']
+
+const NAVIGATOR_TYPES = {
+  createNativeStackNavigator: 'Stack',
+  createStackNavigator: 'Stack',
+  createBottomTabNavigator: 'Tabs',
+  createMaterialBottomTabNavigator: 'Tabs',
+  createMaterialTopTabNavigator: 'TopTabs',
+  createDrawerNavigator: 'Drawer',
+}
+
+// ---------- source discovery ----------
+
+function sourceFiles(ctx) {
+  const seen = new Set()
+  const out = []
+  for (const d of SRC_DIRS) {
+    const abs = d === '.' ? ctx.projectRoot : path.join(ctx.projectRoot, d)
+    if (!ctx.exists(d === '.' ? '.' : d)) continue
+    for (const f of ctx.walk(abs)) {
+      if (!SRC_EXT.test(f) || seen.has(f)) continue
+      // `.` is a last resort for flat projects; it must not re-walk src/
+      seen.add(f)
+      out.push(f)
+    }
+    // A real src/ tree means the root sweep would only add config files.
+    if (d !== '.' && out.length) break
+  }
+  return out
+}
+
+// Read a JSX tag starting at `<`, tracking string and brace nesting so that
+// options={({ route }) => ({ … })} does not end the tag at its first '>'.
+function readTag(src, start) {
+  let depth = 0, i = start, quote = null
+  for (; i < src.length; i++) {
+    const c = src[i]
+    if (quote) {
+      if (c === '\\') i++
+      else if (c === quote) quote = null
+      continue
+    }
+    if (c === '"' || c === "'" || c === '`') { quote = c; continue }
+    if (c === '{') depth++
+    else if (c === '}') depth--
+    else if (c === '>' && depth === 0) return src.slice(start, i + 1)
+  }
+  return src.slice(start, i)
+}
+
+// ---------- constants: name={SCREENS.HOME} / name={HOME_SCREEN} ----------
+
+function buildConstantMap(ctx, files) {
+  const scalars = {}   // HOME_SCREEN → "Home"
+  const objects = {}   // SCREENS → { HOME: "Home" }
+  const SCALAR_RE = /\bexport\s+const\s+([A-Za-z_$][\w$]*)\s*(?::[^=]*)?=\s*["'`]([^"'`]+)["'`]/g
+  const OBJECT_RE = /\bexport\s+const\s+([A-Za-z_$][\w$]*)\s*(?::[^=]*)?=\s*\{([^}]*)\}/g
+  const MEMBER_RE = /([A-Za-z_$][\w$]*)\s*:\s*["'`]([^"'`]+)["'`]/g
+  for (const f of files) {
+    const src = ctx.readFileOrNull(f)
+    if (!src) continue
+    for (const m of src.matchAll(SCALAR_RE)) scalars[m[1]] ??= m[2]
+    for (const m of src.matchAll(OBJECT_RE)) {
+      const members = {}
+      for (const mm of m[2].matchAll(MEMBER_RE)) members[mm[1]] = mm[2]
+      if (Object.keys(members).length) objects[m[1]] ??= members
+    }
+  }
+  return { scalars, objects }
+}
+
+// A Screen's name attribute, whichever form it takes. Returns null when the
+// value is computed in a way static reading cannot follow.
+function resolveName(raw, consts) {
+  if (raw == null) return null
+  const lit = raw.match(/^["'`]([^"'`]+)["'`]$/)
+  if (lit) return lit[1]
+  const member = raw.match(/^([A-Za-z_$][\w$]*)\.([A-Za-z_$][\w$]*)$/)
+  if (member) return consts.objects[member[1]]?.[member[2]] ?? null
+  const ident = raw.match(/^([A-Za-z_$][\w$]*)$/)
+  if (ident) return consts.scalars[ident[1]] ?? null
+  return null
+}
+
+// ---------- linking config ----------
+
+// Pull the balanced { … } that follows `key` at or after `from`.
+function blockAfter(src, key, from = 0) {
+  const at = src.indexOf(key, from)
+  if (at === -1) return null
+  const open = src.indexOf('{', at)
+  if (open === -1) return null
+  let depth = 0, quote = null
+  for (let i = open; i < src.length; i++) {
+    const c = src[i]
+    if (quote) {
+      if (c === '\\') i++
+      else if (c === quote) quote = null
+      continue
+    }
+    if (c === '"' || c === "'" || c === '`') { quote = c; continue }
+    if (c === '{') depth++
+    else if (c === '}' && --depth === 0) return { body: src.slice(open + 1, i), end: i }
+  }
+  return null
+}
+
+// screens: { Home: 'home', Tabs: { screens: { Feed: 'feed' } }, Profile: { path: 'p/:id' } }
+// → { Home: '/home', Feed: '/feed', Profile: '/p/:id' }, plus the parent chain
+// so a nested screen's path inherits its navigator's prefix.
+function parseScreens(body, prefix = '') {
+  const out = {}
+  const ENTRY = /([A-Za-z_$][\w$]*)\s*:\s*/g
+  let m
+  while ((m = ENTRY.exec(body))) {
+    const name = m[1]
+    const rest = body.slice(ENTRY.lastIndex)
+    const strM = rest.match(/^["'`]([^"'`]*)["'`]/)
+    if (strM) {
+      out[name] = joinPath(prefix, strM[1])
+      continue
+    }
+    if (rest.trimStart().startsWith('{')) {
+      const blk = blockAfter(body, '', ENTRY.lastIndex - 1)
+      if (!blk) continue
+      const inner = blk.body
+      const pathM = inner.match(/\bpath\s*:\s*["'`]([^"'`]*)["'`]/)
+      const here = pathM ? joinPath(prefix, pathM[1]) : prefix
+      if (pathM) out[name] = here
+      const nested = blockAfter(inner, 'screens')
+      if (nested) Object.assign(out, parseScreens(nested.body, here))
+      ENTRY.lastIndex = blk.end + 1
+    }
+  }
+  return out
+}
+
+function joinPath(prefix, seg) {
+  const a = (prefix || '').replace(/\/$/, '')
+  const b = (seg || '').replace(/^\//, '')
+  const joined = b ? `${a}/${b}` : a
+  return joined.startsWith('/') ? joined : '/' + joined
+}
+
+function findLinking(ctx, files) {
+  for (const f of files) {
+    const src = ctx.readFileOrNull(f)
+    if (!src || !/\bscreens\s*:/.test(src)) continue
+    // A linking config is a `config: { screens: … }` under a prefixes/linking
+    // declaration — not just any object with a screens key.
+    if (!/\b(linking|prefixes)\b/.test(src)) continue
+    const cfg = blockAfter(src, 'screens')
+    if (!cfg) continue
+    return { file: ctx.rel(f), paths: parseScreens(cfg.body) }
+  }
+  return { file: null, paths: {} }
+}
+
+// ---------- navigators and screens ----------
+
+// The function that renders a navigator, so a nested navigator can be named
+// after the route that mounts it rather than after its variable.
+function enclosingFunction(src, index) {
+  const before = src.slice(0, index)
+  const decls = [
+    ...before.matchAll(/\bfunction\s+([A-Za-z_$][\w$]*)\s*\(/g),
+    ...before.matchAll(/\bconst\s+([A-Za-z_$][\w$]*)\s*(?::[^=]*)?=\s*(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>/g),
+  ].sort((a, b) => a.index - b.index)
+  return decls.length ? decls[decls.length - 1][1] : null
+}
+
+function collectScreens(ctx, files, consts) {
+  const navigators = []  // { key, type, file, rendererFn }
+  const screens = []     // { name, componentIdent, presentation, navKey, file }
+
+  for (const f of files) {
+    const src = ctx.readFileOrNull(f)
+    if (!src || !src.includes('.Screen')) continue
+    const relFile = ctx.rel(f)
+
+    // const Stack = createNativeStackNavigator<Params>()
+    const navTypes = {}
+    for (const m of src.matchAll(
+      /\bconst\s+([A-Za-z_$][\w$]*)\s*=\s*(create[A-Za-z]*Navigator)\s*(?:<[^>]*>)?\s*\(/g
+    )) {
+      navTypes[m[1]] = NAVIGATOR_TYPES[m[2]] ?? 'Stack'
+    }
+
+    for (const m of src.matchAll(/<([A-Za-z_$][\w$]*)\.Navigator\b/g)) {
+      const ident = m[1]
+      const key = `${relFile}::${ident}`
+      if (navigators.some((n) => n.key === key)) continue
+      navigators.push({
+        key, ident, file: relFile,
+        type: navTypes[ident] ?? 'Stack',
+        rendererFn: enclosingFunction(src, m.index),
+      })
+    }
+
+    for (const m of src.matchAll(/<([A-Za-z_$][\w$]*)\.Screen\b/g)) {
+      const tag = readTag(src, m.index)
+      const nameRaw = tag.match(/\bname\s*=\s*(?:\{([^}]*)\}|("(?:[^"]*)"|'(?:[^']*)'))/)
+      const raw = (nameRaw?.[1] ?? nameRaw?.[2] ?? '').trim()
+      const name = resolveName(raw, consts)
+      if (!name) continue
+      const componentIdent =
+        tag.match(/\bcomponent\s*=\s*\{\s*([A-Za-z_$][\w$]*)\s*\}/)?.[1] ??
+        tag.match(/\bgetComponent\s*=\s*\{\s*\(\)\s*=>\s*([A-Za-z_$][\w$]*)\s*\}/)?.[1] ??
+        null
+      screens.push({
+        name,
+        componentIdent,
+        presentation: tag.match(/\bpresentation\s*:\s*["'`]([A-Za-z]+)["'`]/)?.[1] ?? null,
+        navKey: `${relFile}::${m[1]}`,
+        file: relFile,
+        absFile: f,
+      })
+    }
+  }
+  return { navigators, screens }
+}
+
+// identifier → absolute file, for one module's imports
+function importMap(ctx, src, fromFile) {
+  const map = {}
+  const RE = /import\s+(?:([A-Za-z_$][\w$]*)\s*,?\s*)?(?:\{([^}]*)\})?\s*from\s*["']([^"']+)["']/g
+  for (const m of src.matchAll(RE)) {
+    const resolved = ctx.resolveImport(m[3], fromFile)
+    if (!resolved) continue
+    if (m[1]) map[m[1]] = resolved
+    for (const part of (m[2] ?? '').split(',')) {
+      const pm = part.trim().match(/^(?:type\s+)?([A-Za-z_$][\w$]*)(?:\s+as\s+([A-Za-z_$][\w$]*))?$/)
+      if (pm) map[pm[2] ?? pm[1]] = resolved
+    }
+  }
+  return map
+}
+
+// ---------- detection ----------
+
+// expo-router layouts also write <Stack.Screen name="about" />, so the mere
+// presence of a Screen tag proves nothing. What separates the two is the
+// component binding: expo-router resolves screens from the filesystem and never
+// names one, while react-navigation must say which component to render.
+function bindsComponents(src) {
+  for (const m of src.matchAll(/<([A-Za-z_$][\w$]*)\.Screen\b/g)) {
+    const tag = readTag(src, m.index)
+    if (/\b(?:component|getComponent)\s*=\s*\{/.test(tag)) return true
+  }
+  return false
+}
+
+export function detect(ctx) {
+  const evidence = []
+  let score = 0
+  const deps = ctx.deps()
+
+  const navDeps = Object.keys(deps).filter((d) => d.startsWith('@react-navigation/'))
+  if (navDeps.length) {
+    score += 0.4
+    evidence.push(`${navDeps.length} @react-navigation/* dependencies`)
+  }
+  // expo-router owns its own app/ tree; if it is present this is its project.
+  if (deps['expo-router']) {
+    evidence.push('expo-router also present — deferring to it')
+    return { score: Math.min(score, 0.3), evidence }
+  }
+
+  const files = sourceFiles(ctx).slice(0, 4000)
+  const withScreens = files.filter((f) => {
+    const src = ctx.readFileOrNull(f)
+    return src && src.includes('.Screen') && bindsComponents(src)
+  })
+  if (withScreens.length) {
+    score += 0.45
+    evidence.push(`component-bound <X.Screen> in ${withScreens.length} file(s)`)
+  }
+  const linking = findLinking(ctx, files)
+  if (linking.file) {
+    score += 0.15
+    evidence.push(`linking config in ${linking.file}`)
+  }
+  if (!withScreens.length) {
+    // An expo-router tree drags in @react-navigation transitively; without a
+    // single component-bound screen there is nothing here for this provider.
+    return { score: 0, evidence: [...evidence, 'no component-bound screen registrations'] }
+  }
+  return { score: Math.min(score, 1), evidence }
+}
+
+// ---------- parse ----------
+
+export function parse(ctx) {
+  const files = sourceFiles(ctx)
+  const consts = buildConstantMap(ctx, files)
+  const { navigators, screens } = collectScreens(ctx, files, consts)
+  const linking = findLinking(ctx, files)
+
+  if (!screens.length) {
+    throw new Error(
+      'react-navigation: no <X.Screen name=… /> registrations found. ' +
+      'If screens are registered dynamically, use a custom provider ' +
+      '({"routes":{"provider":"custom","command":"…"}}).'
+    )
+  }
+
+  const navByKey = Object.fromEntries(navigators.map((n) => [n.key, n]))
+
+  // A navigator mounted by a Screen takes that route's name as its group, so a
+  // tab navigator reads as "Tabs" rather than as the variable it was assigned
+  // to. Everything else falls back to the navigator type.
+  const mountName = {}
+  const mountedNavKey = {} // container screen name → the navigator it mounts
+  for (const s of screens) {
+    if (!s.componentIdent) continue
+    for (const n of navigators) {
+      if (n.file === s.file && n.rendererFn && n.rendererFn === s.componentIdent) {
+        mountName[n.key] = s.name
+        mountedNavKey[s.name] = n.key
+      }
+    }
+  }
+
+  // A screen whose component *is* another navigator is a mount point, not a
+  // screen: it has no content of its own, and deep-linking it lands on whatever
+  // child is first. expo-router models the same thing as _layout, and layouts
+  // are not routes — so these become layouts here too, and links aimed at them
+  // resolve to the child that actually renders.
+  const containers = new Set(Object.keys(mountedNavKey))
+  const firstChildOf = {}
+  for (const name of containers) {
+    const child = screens.find((s) => s.navKey === mountedNavKey[name])
+    if (child) firstChildOf[name] = child.name
+  }
+
+  // Screen names are unique per navigator, not globally; disambiguate the rare
+  // collision by prefixing the group rather than dropping a route.
+  const nameCount = new Map()
+  for (const s of screens) nameCount.set(s.name, (nameCount.get(s.name) ?? 0) + 1)
+
+  const seenIds = new Set()
+  const routes = []
+  for (const s of screens) {
+    if (containers.has(s.name)) continue
+    const nav = navByKey[s.navKey]
+    const group = mountName[s.navKey] ?? nav?.type ?? ''
+    let id = nameCount.get(s.name) > 1 && group ? `${group}/${s.name}` : s.name
+    while (seenIds.has(id)) id = `${id}_`
+    seenIds.add(id)
+
+    const abs = s.componentIdent
+      ? importMap(ctx, ctx.readFileOrNull(s.absFile) ?? '', s.absFile)[s.componentIdent] ?? null
+      : null
+    const componentSrc = abs ? ctx.readFileOrNull(abs) : null
+
+    const urlPath = linking.paths[s.name] ?? null
+    const stateHints = componentSrc ? extractHints(componentSrc) : []
+    if (s.presentation && /modal/i.test(s.presentation))
+      stateHints.push({ type: 'router-modal', presentation: s.presentation })
+
+    routes.push({
+      id,
+      file: abs ? ctx.rel(abs) : s.file,
+      urlPath,
+      // The registered screen name is what the app's own code calls this
+      // screen, so it beats a URL that may not exist.
+      title: s.name,
+      slug: id.replace(/[^A-Za-z0-9_.-]+/g, '_'),
+      params: urlPath ? urlPath.split('/').filter((x) => x.startsWith(':')).map((x) => x.slice(1)) : [],
+      navigator: nav?.type ?? 'react-navigation',
+      layoutDir: group,
+      presentation: s.presentation,
+      stateHints,
+      _abs: abs,
+      _screenName: s.name,
+    })
+  }
+
+  // ---------- edges ----------
+
+  const byScreenName = new Map()
+  for (const r of routes) if (!byScreenName.has(r._screenName)) byScreenName.set(r._screenName, r)
+  // navigate('Tabs') with no nested screen lands on the container's first child
+  for (const [container, child] of Object.entries(firstChildOf)) {
+    const target = byScreenName.get(child)
+    if (target && !byScreenName.has(container)) byScreenName.set(container, target)
+  }
+  const withUrl = routes.filter((r) => r.urlPath)
+  const matchers = withUrl.map((r) => ({ route: r, re: ctx.routeMatcher(r.urlPath) }))
+
+  // navigate('Profile') · navigate(SCREENS.PROFILE) · navigate('Tabs', { screen: 'Feed' })
+  const NAV_RE = /\b(?:navigate|push|replace|jumpTo)\(\s*(?:["'`]([^"'`]+)["'`]|([A-Za-z_$][\w$.]*))\s*(?:,\s*\{\s*screen\s*:\s*(?:["'`]([^"'`]+)["'`]|([A-Za-z_$][\w$.]*)))?/g
+  const LINK_RE = /(?:href|to)=\{?\s*["'`](\/[^"'`\s]*)["'`]/g
+
+  // Same one-hop-with-fanout-cap rule as expo-router: links live in list items
+  // and cards, not in the screen module itself.
+  const IMPORT_FANOUT_CAP = 8
+  const importsOf = new Map()
+  const fanout = new Map()
+  for (const r of routes) {
+    if (!r._abs) continue
+    const src = ctx.readFileOrNull(r._abs)
+    if (!src) continue
+    const own = ctx.firstPartyImports(src, r.file)
+    importsOf.set(r.id, own)
+    for (const f of new Set(own)) fanout.set(f, (fanout.get(f) ?? 0) + 1)
+  }
+
+  const edges = []
+  for (const r of routes) {
+    if (!r._abs) continue
+    const own = ctx.readFileOrNull(r._abs)
+    if (!own) continue
+    const sources = [own]
+    for (const f of importsOf.get(r.id) ?? []) {
+      if ((fanout.get(f) ?? 0) > IMPORT_FANOUT_CAP) continue
+      const s = ctx.readFileOrNull(path.join(ctx.projectRoot, f))
+      if (s) sources.push(s)
+    }
+    const seen = new Set()
+    for (const src of sources) {
+      for (const m of src.matchAll(NAV_RE)) {
+        // A nested target names the child screen; that is the screen that ends
+        // up on top, so it is the edge worth drawing.
+        const outer = m[1] ?? resolveName(m[2] ?? '', consts)
+        const inner = m[3] ?? (m[4] ? resolveName(m[4], consts) : null)
+        const targetName = inner ?? outer
+        if (!targetName) continue
+        const target = byScreenName.get(targetName)
+        if (!target || seen.has(target.id)) continue
+        seen.add(target.id)
+        edges.push({
+          from: r.id, to: target.id,
+          raw: `navigate('${targetName}')`,
+          target: target.urlPath ?? target.id,
+        })
+      }
+      for (const m of src.matchAll(LINK_RE)) {
+        const t = m[1].split(/[?#]/)[0].replace(/\$\{[^}]*\}/g, 'X') || '/'
+        const hit = matchers.find((x) => x.re.test(t))
+        if (!hit || seen.has(hit.route.id)) continue
+        seen.add(hit.route.id)
+        edges.push({ from: r.id, to: hit.route.id, raw: m[1], target: t })
+      }
+    }
+  }
+
+  for (const r of routes) { delete r._abs; delete r._screenName }
+
+  const layouts = navigators.map((n) => ({
+    file: n.file,
+    dir: mountName[n.key] ?? n.type,
+    navigator: n.type,
+  }))
+
+  return {
+    linkingFile: linking.file,
+    screensResolved: routes.filter((r) => r.file).length,
+    layouts, routes, edges,
+  }
+}

--- a/plugins/screenmap/skills/screenmap/scripts/routes/registry.mjs
+++ b/plugins/screenmap/skills/screenmap/scripts/routes/registry.mjs
@@ -1,0 +1,70 @@
+// The provider registry: which route producers exist, which one fits a
+// project, and how a caller overrides that choice.
+//
+// Adding a framework means adding a module to providers/ and one line here.
+// Nothing else in the pipeline needs to know it exists.
+
+import * as expoRouter from './providers/expo-router.mjs'
+import * as reactNavigation from './providers/react-navigation.mjs'
+import * as custom from './providers/custom.mjs'
+
+export const PROVIDERS = [expoRouter, reactNavigation, custom]
+
+export const byId = (id) => PROVIDERS.find((p) => p.meta.id === id) ?? null
+
+// Below this, a provider is guessing rather than recognising.
+const MIN_SCORE = 0.4
+// Two providers this close cannot be told apart from the filesystem alone.
+const AMBIGUOUS_DELTA = 0.15
+
+export function detectAll(ctx) {
+  return PROVIDERS
+    .map((p) => {
+      let r
+      try { r = p.detect(ctx) } catch (e) { r = { score: 0, evidence: [`detect failed: ${e.message}`] } }
+      return { provider: p, id: p.meta.id, score: r.score ?? 0, evidence: r.evidence ?? [] }
+    })
+    .sort((a, b) => b.score - a.score)
+}
+
+// Returns { provider, detections, reason }. Throws with an actionable message
+// when nothing fits or two providers tie — a run that silently picks the wrong
+// producer costs a whole capture pass to discover.
+export function select(ctx, { provider: explicit = null, config = {} } = {}) {
+  const detections = detectAll(ctx)
+
+  const forced = explicit ?? (config.provider && config.provider !== 'auto' ? config.provider : null)
+  if (forced) {
+    const p = byId(forced)
+    if (!p) {
+      throw new Error(
+        `unknown route provider "${forced}" — expected ${PROVIDERS.map((x) => x.meta.id).join(' | ')}`
+      )
+    }
+    return { provider: p, detections, reason: explicit ? 'requested with --provider' : 'set in .screenmap/config.json' }
+  }
+
+  const [top, second] = detections
+  if (!top || top.score < MIN_SCORE) {
+    throw new Error(
+      `no route provider recognised this project.\n` +
+      formatDetections(detections) +
+      `\nSet routes.provider in .screenmap/config.json, or pass --provider <id>. ` +
+      `To use your own parser: {"routes":{"provider":"custom","command":"node tools/my-parser.mjs"}}`
+    )
+  }
+  if (second && top.score - second.score < AMBIGUOUS_DELTA) {
+    throw new Error(
+      `two route providers fit this project equally well.\n` +
+      formatDetections(detections) +
+      `\nPick one with --provider <id>, or set routes.provider in .screenmap/config.json.`
+    )
+  }
+  return { provider: top.provider, detections, reason: `detected (score ${top.score.toFixed(2)})` }
+}
+
+export function formatDetections(detections) {
+  return detections
+    .map((d) => `  ${d.score.toFixed(2)}  ${d.id.padEnd(18)} ${d.evidence.join('; ') || '—'}`)
+    .join('\n')
+}


### PR DESCRIPTION
## Why

`parse-routes.mjs` dispatched on `if (appDir) expoRouter() else routeMap()`. Three things followed from that one line:

- a react-navigation app whose source lives in `app/` was silently parsed as expo-router;
- the react-navigation path only recognised Bluesky's exact shape — `src/routes.ts` plus a single `src/Navigation.tsx` — and dropped any route whose path didn't start with `/`;
- SKILL.md told the agent to stop outright on such projects ("bare react-navigation apps are not supported yet").

React Navigation is common enough that this is worth fixing properly rather than adding a third `else`.

## What changed

**A provider layer.** `parse-routes.mjs` is now only a driver: detect → select → parse → normalize → validate → emit. Each framework is one module under `routes/providers/`, and the helpers that were trapped inside the expo-router path — tsconfig alias resolution, one-hop import following with the fanout cap, route matching, state hints — are a shared `ctx` toolkit. A provider is ~100 lines of genuinely framework-specific code.

**Detection scores, with evidence, instead of a directory check.** The frameworks genuinely overlap: expo-router runs on react-navigation underneath, and plenty of RN apps keep their source in `app/`. So providers score, and the driver refuses when nothing clears 0.4 or when two tie, rather than picking one silently.

```
0.95  expo-router        app/ contains a _layout route; expo-router in package.json
0.00  react-navigation   expo-router also present — deferring to it
```

Building the fixture caught a false positive immediately: expo-router's `_layout.tsx` also writes `<Stack.Screen name="…">`. The discriminator is the component binding — expo-router resolves screens from the filesystem and never names one.

**Identity split from reachability.** A route now carries `title` (always present), a **nullable** `urlPath`, and `reach`. A react-navigation screen registered on a navigator but absent from the linking config has no URL at all; that's ordinary, not an error, and it still belongs on the map.

`reach: "navigation-only"` is the load-bearing part — it's what makes this work end to end rather than merely parse:

- `deepLinkFor()` returns null instead of the app root, so the capture loop stops screenshotting the home screen and filing it under the wrong route's name;
- it seeds `capture.needsNavigation` in the bundle, so the viewer badges it and replay picks an interactive flow;
- the screen lands on the agent's work queue, and the prompt now says `NO DEEP LINK — reach it by tapping` instead of showing `deepLink=null`;
- SKILL.md Phase 4 branches on it.

**`custom` provider** — runs a command that emits a graph fragment. That's the escape hatch for a home-grown router, and the path a new framework takes before it earns a module here: prototype it out of tree, upstream it once the shape has survived a real app. Verified with a stub SwiftUI parser.

## Verification

- expo-router output is unchanged apart from the new fields, checked field-by-field against a pre-refactor snapshot
- both fixtures pinned by snapshot in `fixtures/run-tests.mjs`, which fails if detection ever re-routes a project to a different provider
- pack → `.scrmap` → unzip: `needsNavigation` propagates for the URL-less screen
- bundles predating `title`/`reach` still load (`graphFromMap` synthesizes both)
- the PR diff lane runs on react-navigation graphs
- viewer builds; labels come from a shared `nodeLabel` helper

```
$ node fixtures/run-tests.mjs
ok   demo-app — expo-router, 7 routes, 10 edges
ok   rn-demo-app — react-navigation, 5 routes, 4 edges
```

## Supersedes #2

Credit to @herbieduah, who reported two of these from mapping a real react-navigation app. Both are fixed here:

- **App named after the directory.** Maps built in a git worktree were titled after the branch. Now read from `app.json` / `app.config.*`. Worth noting that #2's version of this couldn't work — its regex was `/\\bname\\s*:/`, where `\\b` matches a literal backslash, so the `app.config.*` branch never fired and it always fell back to `basename()`. The new fixture uses `app.config.ts` specifically to cover that path.
- **`@expo/ui/community/bottom-sheet`** added to `SHEET_LIBS`.

The third — routes rendering as the literal string `null` — is fixed at the schema level via `title` rather than a `?? r.id` fallback in one renderer, since the viewer and `render-map.mjs` were labelling nodes differently. The instinct behind it was right: today's parser doesn't print `null`, it drops those screens entirely, which is worse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)